### PR TITLE
feat(api): Add support for OpenAI API key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "packages/mukti-api": {
       "name": "@mukti/api",
-      "version": "0.1.0",
+      "version": "0.1.1-beta.0",
       "dependencies": {
         "@nestjs/bullmq": "^11.0.4",
         "@nestjs/common": "^11.0.1",
@@ -60,6 +60,7 @@
         "fast-check": "^4.3.0",
         "helmet": "^8.1.0",
         "mongoose": "^8.19.1",
+        "openai": "^6.17.0",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
@@ -106,7 +107,7 @@
     },
     "packages/mukti-web": {
       "name": "@mukti/web",
-      "version": "0.2.0",
+      "version": "0.2.1-beta.0",
       "dependencies": {
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -3345,7 +3346,7 @@
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
-    "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
+    "openai": ["openai@6.17.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-NHRpPEUPzAvFOAFs9+9pC6+HCw/iWsYsKCMPXH5Kw7BpMxqd8g/A07/1o7Gx2TWtCnzevVRyKMRFqyiHyAlqcA=="],
 
     "opencommit": ["opencommit@3.2.10", "", { "dependencies": { "@actions/core": "^1.10.0", "@actions/exec": "^1.1.1", "@actions/github": "^6.0.1", "@anthropic-ai/sdk": "^0.19.2", "@azure/openai": "^1.0.0-beta.12", "@clack/prompts": "^0.6.1", "@dqbd/tiktoken": "^1.0.2", "@google/generative-ai": "^0.11.4", "@mistralai/mistralai": "^1.3.5", "@octokit/webhooks-schemas": "^6.11.0", "@octokit/webhooks-types": "^6.11.0", "axios": "^1.3.4", "chalk": "^5.2.0", "cleye": "^1.3.2", "crypto": "^1.0.1", "execa": "^7.0.0", "ignore": "^5.2.4", "ini": "^3.0.1", "inquirer": "^9.1.4", "openai": "^4.57.0", "punycode": "^2.3.1", "zod": "^3.23.8" }, "bin": { "opencommit": "out/cli.cjs", "oco": "out/cli.cjs" } }, "sha512-/vmqGGVUct6RbymjLdpZgN2xb7bkMI4sFZXdytCezJ5XFzNELssrC4d0f2dahqsKsMMAivVGmxh3Dok+0gwYEQ=="],
 
@@ -4385,8 +4386,6 @@
 
     "@module-federation/webpack-bundler-runtime/@module-federation/runtime": ["@module-federation/runtime@0.18.4", "", { "dependencies": { "@module-federation/error-codes": "0.18.4", "@module-federation/runtime-core": "0.18.4", "@module-federation/sdk": "0.18.4" } }, "sha512-2et6p7pjGRHzpmrW425jt/BiAU7QHgkZtbQB7pj01eQ8qx6SloFEBk9ODnV8/ztSm9H2T3d8GxXA6/9xVOslmQ=="],
 
-    "@mukti/api/@swc/core": ["@swc/core@1.15.3", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.3", "@swc/core-darwin-x64": "1.15.3", "@swc/core-linux-arm-gnueabihf": "1.15.3", "@swc/core-linux-arm64-gnu": "1.15.3", "@swc/core-linux-arm64-musl": "1.15.3", "@swc/core-linux-x64-gnu": "1.15.3", "@swc/core-linux-x64-musl": "1.15.3", "@swc/core-win32-arm64-msvc": "1.15.3", "@swc/core-win32-ia32-msvc": "1.15.3", "@swc/core-win32-x64-msvc": "1.15.3" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q=="],
-
     "@mukti/api/eslint": ["eslint@9.39.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.1", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g=="],
 
     "@mukti/api/jest": ["jest@29.7.0", "", { "dependencies": { "@jest/core": "^29.7.0", "@jest/types": "^29.6.3", "import-local": "^3.0.2", "jest-cli": "^29.7.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"], "bin": { "jest": "bin/jest.js" } }, "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw=="],
@@ -4873,7 +4872,7 @@
 
     "nx/ora": ["ora@5.3.0", "", { "dependencies": { "bl": "^4.0.3", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "log-symbols": "^4.0.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g=="],
 
-    "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+    "opencommit/openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "opencommit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -5106,26 +5105,6 @@
     "@module-federation/runtime-tools/@module-federation/runtime/@module-federation/runtime-core": ["@module-federation/runtime-core@0.18.4", "", { "dependencies": { "@module-federation/error-codes": "0.18.4", "@module-federation/sdk": "0.18.4" } }, "sha512-LGGlFXlNeTbIGBFDiOvg0zz4jBWCGPqQatXdKx7mylXhDij7YmwbuW19oenX+P1fGhmoBUBM5WndmR87U66qWA=="],
 
     "@module-federation/webpack-bundler-runtime/@module-federation/runtime/@module-federation/runtime-core": ["@module-federation/runtime-core@0.18.4", "", { "dependencies": { "@module-federation/error-codes": "0.18.4", "@module-federation/sdk": "0.18.4" } }, "sha512-LGGlFXlNeTbIGBFDiOvg0zz4jBWCGPqQatXdKx7mylXhDij7YmwbuW19oenX+P1fGhmoBUBM5WndmR87U66qWA=="],
-
-    "@mukti/api/@swc/core/@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AXfeQn0CvcQ4cndlIshETx6jrAM45oeUrK8YeEY6oUZU/qzz0Id0CyvlEywxkWVC81Ajpd8TQQ1fW5yx6zQWkQ=="],
-
-    "@mukti/api/@swc/core/@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-p68OeCz1ui+MZYG4wmfJGvcsAcFYb6Sl25H9TxWl+GkBgmNimIiRdnypK9nBGlqMZAcxngNPtnG3kEMNnvoJ2A=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Nuj5iF4JteFgwrai97mUX+xUOl+rQRHqTvnvHMATL/l9xE6/TJfPBpd3hk/PVpClMXG3Uvk1MxUFOEzM1JrMYg=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-2Nc/s8jE6mW2EjXWxO/lyQuLKShcmTrym2LRf5Ayp3ICEMX6HwFqB1EzDhwoMa2DcUgmnZIalesq2lG3krrUNw=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.3", "", { "os": "linux", "cpu": "x64" }, "sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.3", "", { "os": "linux", "cpu": "x64" }, "sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug=="],
-
-    "@mukti/api/@swc/core/@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA=="],
-
-    "@mukti/api/@swc/core/@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-B8UtogMzErUPDWUoKONSVBdsgKYd58rRyv2sHJWKOIMCHfZ22FVXICR4O/VwIYtlnZ7ahERcjayBHDlBZpR0aw=="],
-
-    "@mukti/api/@swc/core/@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.3", "", { "os": "win32", "cpu": "x64" }, "sha512-SpZKMR9QBTecHeqpzJdYEfgw30Oo8b/Xl6rjSzBt1g0ZsXyy60KLXrp6IagQyfTYqNYE/caDvwtF2FPn7pomog=="],
 
     "@mukti/api/eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -5521,7 +5500,7 @@
 
     "nx/figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
-    "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+    "opencommit/openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -5886,6 +5865,8 @@
     "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "opencommit/openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/packages/mukti-api/package.json
+++ b/packages/mukti-api/package.json
@@ -44,6 +44,7 @@
     "fast-check": "^4.3.0",
     "helmet": "^8.1.0",
     "mongoose": "^8.19.1",
+    "openai": "^6.17.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",

--- a/packages/mukti-api/src/modules/ai/ai.module.ts
+++ b/packages/mukti-api/src/modules/ai/ai.module.ts
@@ -6,6 +6,7 @@ import { User, UserSchema } from '../../schemas/user.schema';
 import { AiController } from './ai.controller';
 import { AiPolicyService } from './services/ai-policy.service';
 import { AiSecretsService } from './services/ai-secrets.service';
+import { OpenAiClientFactory } from './services/openai-client.factory';
 import { OpenRouterClientFactory } from './services/openrouter-client.factory';
 import { OpenRouterModelsService } from './services/openrouter-models.service';
 
@@ -14,6 +15,7 @@ import { OpenRouterModelsService } from './services/openrouter-models.service';
   exports: [
     AiPolicyService,
     AiSecretsService,
+    OpenAiClientFactory,
     OpenRouterClientFactory,
     OpenRouterModelsService,
   ],
@@ -24,6 +26,7 @@ import { OpenRouterModelsService } from './services/openrouter-models.service';
   providers: [
     AiPolicyService,
     AiSecretsService,
+    OpenAiClientFactory,
     OpenRouterClientFactory,
     OpenRouterModelsService,
   ],

--- a/packages/mukti-api/src/modules/ai/dto/openai-key.dto.ts
+++ b/packages/mukti-api/src/modules/ai/dto/openai-key.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class SetOpenAiKeyDto {
+  @ApiProperty({
+    description: 'User-provided OpenAI API key',
+    example: 'sk-...',
+    minLength: 10,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(10)
+  apiKey: string;
+}

--- a/packages/mukti-api/src/modules/ai/services/ai-policy.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/ai-policy.service.ts
@@ -53,6 +53,10 @@ export class AiPolicyService {
     return !!user.openRouterApiKeyEncrypted;
   }
 
+  hasUserOpenAiKey(user: Pick<User, 'openAiApiKeyEncrypted'>): boolean {
+    return !!user.openAiApiKeyEncrypted;
+  }
+
   async resolveEffectiveModel(params: {
     hasByok: boolean;
     requestedModel?: string;

--- a/packages/mukti-api/src/modules/ai/services/openai-client.factory.ts
+++ b/packages/mukti-api/src/modules/ai/services/openai-client.factory.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import OpenAI from 'openai';
+
+@Injectable()
+export class OpenAiClientFactory {
+  create(apiKey: string): OpenAI {
+    return new OpenAI({ apiKey });
+  }
+}

--- a/packages/mukti-api/src/schemas/user.schema.ts
+++ b/packages/mukti-api/src/schemas/user.schema.ts
@@ -68,6 +68,15 @@ export class User {
   openRouterApiKeyUpdatedAt?: Date;
 
   @Prop({ required: false, select: false, type: String })
+  openAiApiKeyEncrypted?: string;
+
+  @Prop({ type: String })
+  openAiApiKeyLast4?: string;
+
+  @Prop({ type: Date })
+  openAiApiKeyUpdatedAt?: Date;
+
+  @Prop({ required: false, select: false, type: String })
   password?: string; // Optional for OAuth users
 
   @Prop({ type: Date })

--- a/packages/mukti-web/src/app/dashboard/settings/page.tsx
+++ b/packages/mukti-web/src/app/dashboard/settings/page.tsx
@@ -15,18 +15,25 @@ export default function SettingsPage() {
     activeModel,
     deleteOpenRouterKey,
     hasOpenRouterKey,
+    hasOpenAiKey,
     hydrate,
     isHydrated,
     models,
+    openAiKeyLast4,
     openRouterKeyLast4,
     refreshModels,
     setActiveModel,
     setOpenRouterKey,
+    setOpenAiKey,
+    deleteOpenAiKey,
   } = useAiStore();
 
   const [apiKey, setApiKey] = useState('');
+  const [openAiKey, setOpenAiKeyInput] = useState('');
   const [savingKey, setSavingKey] = useState(false);
+  const [savingOpenAiKey, setSavingOpenAiKey] = useState(false);
   const [removingKey, setRemovingKey] = useState(false);
+  const [removingOpenAiKey, setRemovingOpenAiKey] = useState(false);
   const [savingModel, setSavingModel] = useState(false);
 
   useEffect(() => {
@@ -153,6 +160,84 @@ export default function SettingsPage() {
             </div>
 
             {savingKey && <p className="text-xs text-muted-foreground">Saving key…</p>}
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border p-4">
+          <h3 className="text-lg font-semibold">OpenAI API key</h3>
+          <p className="text-sm text-muted-foreground">Connect your OpenAI API key.</p>
+
+          <div className="space-y-2">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                aria-label="OpenAI API key"
+                className="h-11 flex-1"
+                disabled={hasOpenAiKey}
+                onChange={(e) => setOpenAiKeyInput(e.target.value)}
+                placeholder={hasOpenAiKey ? 'Remove existing key to add a new one' : 'sk-…'}
+                type="password"
+                value={openAiKey}
+              />
+              <Button
+                className="h-11 px-4 shrink-0"
+                disabled={savingOpenAiKey || openAiKey.trim().length === 0 || hasOpenAiKey}
+                onClick={async () => {
+                  setSavingOpenAiKey(true);
+                  try {
+                    await setOpenAiKey(openAiKey);
+                    setOpenAiKeyInput('');
+                  } finally {
+                    setSavingOpenAiKey(false);
+                  }
+                }}
+                type="button"
+              >
+                Save key
+              </Button>
+            </div>
+
+            <div className="flex items-center justify-between gap-3 min-h-[44px]">
+              <div>
+                {hasOpenAiKey ? (
+                  <Badge
+                    className="gap-1.5 border-green-500/50 bg-green-500/10 py-1.5 px-3 text-sm text-green-500 h-9"
+                    variant="outline"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    Connected (…{openAiKeyLast4 ?? '????'})
+                  </Badge>
+                ) : (
+                  <Badge
+                    className="gap-1.5 py-1.5 px-3 text-sm text-muted-foreground h-9"
+                    variant="secondary"
+                  >
+                    <AlertCircle className="h-4 w-4" />
+                    Not connected
+                  </Badge>
+                )}
+              </div>
+              {hasOpenAiKey && (
+                <Button
+                  className="h-9 px-4 hover:bg-red-900/20 hover:text-red-400"
+                  disabled={removingOpenAiKey}
+                  onClick={async () => {
+                    setRemovingOpenAiKey(true);
+                    try {
+                      await deleteOpenAiKey();
+                    } finally {
+                      setRemovingOpenAiKey(false);
+                    }
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  <span className="text-red-400">Remove key</span>
+                </Button>
+              )}
+            </div>
+
+            {savingOpenAiKey && <p className="text-xs text-muted-foreground">Saving key…</p>}
           </div>
         </section>
       </div>

--- a/packages/mukti-web/src/lib/api/ai.ts
+++ b/packages/mukti-web/src/lib/api/ai.ts
@@ -2,7 +2,9 @@ import { apiClient } from './client';
 
 export type AiSettings = {
   activeModel?: string;
+  hasOpenAiKey: boolean;
   hasOpenRouterKey: boolean;
+  openAiKeyLast4: null | string;
   openRouterKeyLast4: null | string;
 };
 
@@ -22,6 +24,13 @@ export const aiApi = {
     return apiClient.delete<{ hasOpenRouterKey: boolean; openRouterKeyLast4: null }>(
       '/ai/openrouter-key'
     );
+  },
+
+  deleteOpenAiKey: async (): Promise<{
+    hasOpenAiKey: boolean;
+    openAiKeyLast4: null;
+  }> => {
+    return apiClient.delete<{ hasOpenAiKey: boolean; openAiKeyLast4: null }>('/ai/openai-key');
   },
 
   getModels: async (): Promise<AiModelsResponse> => {
@@ -52,6 +61,12 @@ export const aiApi = {
       '/ai/openrouter-key',
       dto
     );
+  },
+
+  setOpenAiKey: async (dto: {
+    apiKey: string;
+  }): Promise<{ hasOpenAiKey: boolean; openAiKeyLast4: string }> => {
+    return apiClient.put<{ hasOpenAiKey: boolean; openAiKeyLast4: string }>('/ai/openai-key', dto);
   },
 
   updateSettings: async (dto: { activeModel: string }): Promise<{ activeModel: string }> => {

--- a/packages/mukti-web/src/lib/stores/ai-store.ts
+++ b/packages/mukti-web/src/lib/stores/ai-store.ts
@@ -11,25 +11,34 @@ export type AiModelOption = {
 
 interface AiStoreState {
   activeModel: null | string;
+  deleteOpenAiKey: () => Promise<void>;
   deleteOpenRouterKey: () => Promise<void>;
+  hasOpenAiKey: boolean;
   hasOpenRouterKey: boolean;
   hydrate: () => Promise<void>;
   isHydrated: boolean;
   mode: AiModelMode;
 
   models: AiModelOption[];
+  openAiKeyLast4: null | string;
   openRouterKeyLast4: null | string;
   refreshModels: () => Promise<void>;
   setActiveModel: (model: string) => Promise<void>;
+  setOpenAiKey: (apiKey: string) => Promise<void>;
   setOpenRouterKey: (apiKey: string) => Promise<void>;
 }
 
 export const useAiStore = create<AiStoreState>((set, get) => ({
   activeModel: 'openai/gpt-5-mini',
+  deleteOpenAiKey: async () => {
+    await aiApi.deleteOpenAiKey();
+    await get().hydrate();
+  },
   deleteOpenRouterKey: async () => {
     await aiApi.deleteOpenRouterKey();
     await get().hydrate();
   },
+  hasOpenAiKey: false,
   hasOpenRouterKey: false,
   hydrate: async () => {
     try {
@@ -37,8 +46,10 @@ export const useAiStore = create<AiStoreState>((set, get) => ({
 
       set({
         activeModel: settings.activeModel ?? 'openai/gpt-5-mini',
+        hasOpenAiKey: settings.hasOpenAiKey,
         hasOpenRouterKey: settings.hasOpenRouterKey,
         isHydrated: true,
+        openAiKeyLast4: settings.openAiKeyLast4,
         openRouterKeyLast4: settings.openRouterKeyLast4,
       });
 
@@ -53,6 +64,7 @@ export const useAiStore = create<AiStoreState>((set, get) => ({
 
   models: [],
 
+  openAiKeyLast4: null,
   openRouterKeyLast4: null,
 
   refreshModels: async () => {
@@ -79,6 +91,11 @@ export const useAiStore = create<AiStoreState>((set, get) => ({
   setActiveModel: async (model: string) => {
     set({ activeModel: model });
     await aiApi.updateSettings({ activeModel: model });
+  },
+
+  setOpenAiKey: async (apiKey: string) => {
+    await aiApi.setOpenAiKey({ apiKey });
+    await get().hydrate();
   },
 
   setOpenRouterKey: async (apiKey: string) => {


### PR DESCRIPTION
This PR adds support for configuring an OpenAI API key in the settings, alongside the existing keys.

Changes:
- Backend: Added OpenAI fields to User schema, new DTOs, and Controller endpoints.
- Backend: Added OpenAiClientFactory.
- Frontend: Added OpenAI API key management in AI Settings.