### PR TITLE
feat(api): Add support for Anthropic API key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,8 +35,9 @@
     },
     "packages/mukti-api": {
       "name": "@mukti/api",
-      "version": "0.1.0",
+      "version": "0.1.1-beta.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.72.1",
         "@nestjs/bullmq": "^11.0.4",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -106,7 +107,7 @@
     },
     "packages/mukti-web": {
       "name": "@mukti/web",
-      "version": "0.2.0",
+      "version": "0.2.1-beta.0",
       "dependencies": {
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -193,7 +194,7 @@
 
     "@angular-devkit/schematics-cli": ["@angular-devkit/schematics-cli@19.2.19", "", { "dependencies": { "@angular-devkit/core": "19.2.19", "@angular-devkit/schematics": "19.2.19", "@inquirer/prompts": "7.3.2", "ansi-colors": "4.1.3", "symbol-observable": "4.0.0", "yargs-parser": "21.1.1" }, "bin": { "schematics": "bin/schematics.js" } }, "sha512-7q9UY6HK6sccL9F3cqGRUwKhM7b/XfD2YcVaZ2WD7VMaRlRm85v6mRjSrfKIAwxcQU0UK27kMc79NIIqaHjzxA=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.19.2", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7", "web-streams-polyfill": "^3.2.1" } }, "sha512-lsMl7IOFpFCZKUbNdLR0bYN8bevAmvw1Ak79Pp9RIFMwU6nMsMiWWhuBqccK8wi25h6skWE/lY/c0x29rEJFMw=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.72.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -2903,6 +2904,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
@@ -4017,6 +4020,8 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "ts-jest": ["ts-jest@29.4.6", "", { "dependencies": { "bs-logger": "^0.2.6", "fast-json-stable-stringify": "^2.1.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "lodash.memoize": "^4.1.2", "make-error": "^1.3.6", "semver": "^7.7.3", "type-fest": "^4.41.0", "yargs-parser": "^21.1.1" }, "peerDependencies": { "@babel/core": ">=7.0.0-beta.0 <8", "@jest/transform": "^29.0.0 || ^30.0.0", "@jest/types": "^29.0.0 || ^30.0.0", "babel-jest": "^29.0.0 || ^30.0.0", "jest": "^29.0.0 || ^30.0.0", "jest-util": "^29.0.0 || ^30.0.0", "typescript": ">=4.3 <6" }, "optionalPeers": ["@babel/core", "@jest/transform", "@jest/types", "babel-jest", "jest-util"], "bin": { "ts-jest": "cli.js" } }, "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA=="],
@@ -4271,8 +4276,6 @@
 
     "@angular-devkit/schematics-cli/@inquirer/prompts": ["@inquirer/prompts@7.3.2", "", { "dependencies": { "@inquirer/checkbox": "^4.1.2", "@inquirer/confirm": "^5.1.6", "@inquirer/editor": "^4.2.7", "@inquirer/expand": "^4.0.9", "@inquirer/input": "^4.1.6", "@inquirer/number": "^3.0.9", "@inquirer/password": "^4.0.9", "@inquirer/rawlist": "^4.0.9", "@inquirer/search": "^3.0.9", "@inquirer/select": "^4.0.9" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ=="],
 
-    "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
-
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -4384,8 +4387,6 @@
     "@module-federation/third-party-dts-extractor/resolve": ["resolve@1.22.8", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw=="],
 
     "@module-federation/webpack-bundler-runtime/@module-federation/runtime": ["@module-federation/runtime@0.18.4", "", { "dependencies": { "@module-federation/error-codes": "0.18.4", "@module-federation/runtime-core": "0.18.4", "@module-federation/sdk": "0.18.4" } }, "sha512-2et6p7pjGRHzpmrW425jt/BiAU7QHgkZtbQB7pj01eQ8qx6SloFEBk9ODnV8/ztSm9H2T3d8GxXA6/9xVOslmQ=="],
-
-    "@mukti/api/@swc/core": ["@swc/core@1.15.3", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.3", "@swc/core-darwin-x64": "1.15.3", "@swc/core-linux-arm-gnueabihf": "1.15.3", "@swc/core-linux-arm64-gnu": "1.15.3", "@swc/core-linux-arm64-musl": "1.15.3", "@swc/core-linux-x64-gnu": "1.15.3", "@swc/core-linux-x64-musl": "1.15.3", "@swc/core-win32-arm64-msvc": "1.15.3", "@swc/core-win32-ia32-msvc": "1.15.3", "@swc/core-win32-x64-msvc": "1.15.3" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q=="],
 
     "@mukti/api/eslint": ["eslint@9.39.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.1", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g=="],
 
@@ -4875,6 +4876,8 @@
 
     "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "opencommit/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.19.2", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7", "web-streams-polyfill": "^3.2.1" } }, "sha512-lsMl7IOFpFCZKUbNdLR0bYN8bevAmvw1Ak79Pp9RIFMwU6nMsMiWWhuBqccK8wi25h6skWE/lY/c0x29rEJFMw=="],
+
     "opencommit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -5045,8 +5048,6 @@
 
     "@angular-devkit/core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@commitlint/top-level/find-up/locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
@@ -5106,26 +5107,6 @@
     "@module-federation/runtime-tools/@module-federation/runtime/@module-federation/runtime-core": ["@module-federation/runtime-core@0.18.4", "", { "dependencies": { "@module-federation/error-codes": "0.18.4", "@module-federation/sdk": "0.18.4" } }, "sha512-LGGlFXlNeTbIGBFDiOvg0zz4jBWCGPqQatXdKx7mylXhDij7YmwbuW19oenX+P1fGhmoBUBM5WndmR87U66qWA=="],
 
     "@module-federation/webpack-bundler-runtime/@module-federation/runtime/@module-federation/runtime-core": ["@module-federation/runtime-core@0.18.4", "", { "dependencies": { "@module-federation/error-codes": "0.18.4", "@module-federation/sdk": "0.18.4" } }, "sha512-LGGlFXlNeTbIGBFDiOvg0zz4jBWCGPqQatXdKx7mylXhDij7YmwbuW19oenX+P1fGhmoBUBM5WndmR87U66qWA=="],
-
-    "@mukti/api/@swc/core/@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AXfeQn0CvcQ4cndlIshETx6jrAM45oeUrK8YeEY6oUZU/qzz0Id0CyvlEywxkWVC81Ajpd8TQQ1fW5yx6zQWkQ=="],
-
-    "@mukti/api/@swc/core/@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-p68OeCz1ui+MZYG4wmfJGvcsAcFYb6Sl25H9TxWl+GkBgmNimIiRdnypK9nBGlqMZAcxngNPtnG3kEMNnvoJ2A=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Nuj5iF4JteFgwrai97mUX+xUOl+rQRHqTvnvHMATL/l9xE6/TJfPBpd3hk/PVpClMXG3Uvk1MxUFOEzM1JrMYg=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-2Nc/s8jE6mW2EjXWxO/lyQuLKShcmTrym2LRf5Ayp3ICEMX6HwFqB1EzDhwoMa2DcUgmnZIalesq2lG3krrUNw=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.3", "", { "os": "linux", "cpu": "x64" }, "sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A=="],
-
-    "@mukti/api/@swc/core/@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.3", "", { "os": "linux", "cpu": "x64" }, "sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug=="],
-
-    "@mukti/api/@swc/core/@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA=="],
-
-    "@mukti/api/@swc/core/@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-B8UtogMzErUPDWUoKONSVBdsgKYd58rRyv2sHJWKOIMCHfZ22FVXICR4O/VwIYtlnZ7ahERcjayBHDlBZpR0aw=="],
-
-    "@mukti/api/@swc/core/@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.3", "", { "os": "win32", "cpu": "x64" }, "sha512-SpZKMR9QBTecHeqpzJdYEfgw30Oo8b/Xl6rjSzBt1g0ZsXyy60KLXrp6IagQyfTYqNYE/caDvwtF2FPn7pomog=="],
 
     "@mukti/api/eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -5523,6 +5504,8 @@
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
+    "opencommit/@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "postcss-loader/cosmiconfig/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
@@ -5886,6 +5869,8 @@
     "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "opencommit/@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/packages/mukti-api/package.json
+++ b/packages/mukti-api/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.72.1",
     "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/packages/mukti-api/src/modules/ai/ai.module.ts
+++ b/packages/mukti-api/src/modules/ai/ai.module.ts
@@ -6,6 +6,7 @@ import { User, UserSchema } from '../../schemas/user.schema';
 import { AiController } from './ai.controller';
 import { AiPolicyService } from './services/ai-policy.service';
 import { AiSecretsService } from './services/ai-secrets.service';
+import { AnthropicClientFactory } from './services/anthropic-client.factory';
 import { OpenRouterClientFactory } from './services/openrouter-client.factory';
 import { OpenRouterModelsService } from './services/openrouter-models.service';
 
@@ -14,6 +15,7 @@ import { OpenRouterModelsService } from './services/openrouter-models.service';
   exports: [
     AiPolicyService,
     AiSecretsService,
+    AnthropicClientFactory,
     OpenRouterClientFactory,
     OpenRouterModelsService,
   ],
@@ -24,6 +26,7 @@ import { OpenRouterModelsService } from './services/openrouter-models.service';
   providers: [
     AiPolicyService,
     AiSecretsService,
+    AnthropicClientFactory,
     OpenRouterClientFactory,
     OpenRouterModelsService,
   ],

--- a/packages/mukti-api/src/modules/ai/dto/anthropic-key.dto.ts
+++ b/packages/mukti-api/src/modules/ai/dto/anthropic-key.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class SetAnthropicKeyDto {
+  @ApiProperty({
+    description: 'User-provided Anthropic API key',
+    example: 'sk-ant-...',
+    minLength: 10,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(10)
+  apiKey: string;
+}

--- a/packages/mukti-api/src/modules/ai/services/ai-policy.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/ai-policy.service.ts
@@ -53,6 +53,10 @@ export class AiPolicyService {
     return !!user.openRouterApiKeyEncrypted;
   }
 
+  hasUserAnthropicKey(user: Pick<User, 'anthropicApiKeyEncrypted'>): boolean {
+    return !!user.anthropicApiKeyEncrypted;
+  }
+
   async resolveEffectiveModel(params: {
     hasByok: boolean;
     requestedModel?: string;

--- a/packages/mukti-api/src/modules/ai/services/anthropic-client.factory.ts
+++ b/packages/mukti-api/src/modules/ai/services/anthropic-client.factory.ts
@@ -1,0 +1,9 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AnthropicClientFactory {
+  create(apiKey: string): Anthropic {
+    return new Anthropic({ apiKey });
+  }
+}

--- a/packages/mukti-api/src/schemas/user.schema.ts
+++ b/packages/mukti-api/src/schemas/user.schema.ts
@@ -68,6 +68,15 @@ export class User {
   openRouterApiKeyUpdatedAt?: Date;
 
   @Prop({ required: false, select: false, type: String })
+  anthropicApiKeyEncrypted?: string;
+
+  @Prop({ type: String })
+  anthropicApiKeyLast4?: string;
+
+  @Prop({ type: Date })
+  anthropicApiKeyUpdatedAt?: Date;
+
+  @Prop({ required: false, select: false, type: String })
   password?: string; // Optional for OAuth users
 
   @Prop({ type: Date })

--- a/packages/mukti-web/src/app/dashboard/settings/page.tsx
+++ b/packages/mukti-web/src/app/dashboard/settings/page.tsx
@@ -13,7 +13,10 @@ import { useAiStore } from '@/lib/stores/ai-store';
 export default function SettingsPage() {
   const {
     activeModel,
+    anthropicKeyLast4,
+    deleteAnthropicKey,
     deleteOpenRouterKey,
+    hasAnthropicKey,
     hasOpenRouterKey,
     hydrate,
     isHydrated,
@@ -21,12 +24,16 @@ export default function SettingsPage() {
     openRouterKeyLast4,
     refreshModels,
     setActiveModel,
+    setAnthropicKey,
     setOpenRouterKey,
   } = useAiStore();
 
   const [apiKey, setApiKey] = useState('');
+  const [anthropicKey, setAnthropicKeyInput] = useState('');
   const [savingKey, setSavingKey] = useState(false);
+  const [savingAnthropicKey, setSavingAnthropicKey] = useState(false);
   const [removingKey, setRemovingKey] = useState(false);
+  const [removingAnthropicKey, setRemovingAnthropicKey] = useState(false);
   const [savingModel, setSavingModel] = useState(false);
 
   useEffect(() => {
@@ -153,6 +160,84 @@ export default function SettingsPage() {
             </div>
 
             {savingKey && <p className="text-xs text-muted-foreground">Saving key…</p>}
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border p-4">
+          <h3 className="text-lg font-semibold">Anthropic API key</h3>
+          <p className="text-sm text-muted-foreground">Connect your Anthropic API key.</p>
+
+          <div className="space-y-2">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                aria-label="Anthropic API key"
+                className="h-11 flex-1"
+                disabled={hasAnthropicKey}
+                onChange={(e) => setAnthropicKeyInput(e.target.value)}
+                placeholder={hasAnthropicKey ? 'Remove existing key to add a new one' : 'sk-ant-…'}
+                type="password"
+                value={anthropicKey}
+              />
+              <Button
+                className="h-11 px-4 shrink-0"
+                disabled={savingAnthropicKey || anthropicKey.trim().length === 0 || hasAnthropicKey}
+                onClick={async () => {
+                  setSavingAnthropicKey(true);
+                  try {
+                    await setAnthropicKey(anthropicKey);
+                    setAnthropicKeyInput('');
+                  } finally {
+                    setSavingAnthropicKey(false);
+                  }
+                }}
+                type="button"
+              >
+                Save key
+              </Button>
+            </div>
+
+            <div className="flex items-center justify-between gap-3 min-h-[44px]">
+              <div>
+                {hasAnthropicKey ? (
+                  <Badge
+                    className="gap-1.5 border-green-500/50 bg-green-500/10 py-1.5 px-3 text-sm text-green-500 h-9"
+                    variant="outline"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    Connected (…{anthropicKeyLast4 ?? '????'})
+                  </Badge>
+                ) : (
+                  <Badge
+                    className="gap-1.5 py-1.5 px-3 text-sm text-muted-foreground h-9"
+                    variant="secondary"
+                  >
+                    <AlertCircle className="h-4 w-4" />
+                    Not connected
+                  </Badge>
+                )}
+              </div>
+              {hasAnthropicKey && (
+                <Button
+                  className="h-9 px-4 hover:bg-red-900/20 hover:text-red-400"
+                  disabled={removingAnthropicKey}
+                  onClick={async () => {
+                    setRemovingAnthropicKey(true);
+                    try {
+                      await deleteAnthropicKey();
+                    } finally {
+                      setRemovingAnthropicKey(false);
+                    }
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  <span className="text-red-400">Remove key</span>
+                </Button>
+              )}
+            </div>
+
+            {savingAnthropicKey && <p className="text-xs text-muted-foreground">Saving key…</p>}
           </div>
         </section>
       </div>

--- a/packages/mukti-web/src/lib/api/ai.ts
+++ b/packages/mukti-web/src/lib/api/ai.ts
@@ -2,6 +2,8 @@ import { apiClient } from './client';
 
 export type AiSettings = {
   activeModel?: string;
+  anthropicKeyLast4: null | string;
+  hasAnthropicKey: boolean;
   hasOpenRouterKey: boolean;
   openRouterKeyLast4: null | string;
 };
@@ -15,6 +17,15 @@ type CuratedModel = { id: string; label: string };
 type OpenRouterModel = { id: string; name: string };
 
 export const aiApi = {
+  deleteAnthropicKey: async (): Promise<{
+    anthropicKeyLast4: null;
+    hasAnthropicKey: boolean;
+  }> => {
+    return apiClient.delete<{ anthropicKeyLast4: null; hasAnthropicKey: boolean }>(
+      '/ai/anthropic-key'
+    );
+  },
+
   deleteOpenRouterKey: async (): Promise<{
     hasOpenRouterKey: boolean;
     openRouterKeyLast4: null;
@@ -43,6 +54,15 @@ export const aiApi = {
       openRouterKeyLast4: null | string;
     }>('/ai/settings');
     return response;
+  },
+
+  setAnthropicKey: async (dto: {
+    apiKey: string;
+  }): Promise<{ anthropicKeyLast4: string; hasAnthropicKey: boolean }> => {
+    return apiClient.put<{ anthropicKeyLast4: string; hasAnthropicKey: boolean }>(
+      '/ai/anthropic-key',
+      dto
+    );
   },
 
   setOpenRouterKey: async (dto: {

--- a/packages/mukti-web/src/lib/stores/ai-store.ts
+++ b/packages/mukti-web/src/lib/stores/ai-store.ts
@@ -11,7 +11,10 @@ export type AiModelOption = {
 
 interface AiStoreState {
   activeModel: null | string;
+  anthropicKeyLast4: null | string;
+  deleteAnthropicKey: () => Promise<void>;
   deleteOpenRouterKey: () => Promise<void>;
+  hasAnthropicKey: boolean;
   hasOpenRouterKey: boolean;
   hydrate: () => Promise<void>;
   isHydrated: boolean;
@@ -21,15 +24,22 @@ interface AiStoreState {
   openRouterKeyLast4: null | string;
   refreshModels: () => Promise<void>;
   setActiveModel: (model: string) => Promise<void>;
+  setAnthropicKey: (apiKey: string) => Promise<void>;
   setOpenRouterKey: (apiKey: string) => Promise<void>;
 }
 
 export const useAiStore = create<AiStoreState>((set, get) => ({
   activeModel: 'openai/gpt-5-mini',
+  anthropicKeyLast4: null,
+  deleteAnthropicKey: async () => {
+    await aiApi.deleteAnthropicKey();
+    await get().hydrate();
+  },
   deleteOpenRouterKey: async () => {
     await aiApi.deleteOpenRouterKey();
     await get().hydrate();
   },
+  hasAnthropicKey: false,
   hasOpenRouterKey: false,
   hydrate: async () => {
     try {
@@ -37,6 +47,8 @@ export const useAiStore = create<AiStoreState>((set, get) => ({
 
       set({
         activeModel: settings.activeModel ?? 'openai/gpt-5-mini',
+        anthropicKeyLast4: settings.anthropicKeyLast4,
+        hasAnthropicKey: settings.hasAnthropicKey,
         hasOpenRouterKey: settings.hasOpenRouterKey,
         isHydrated: true,
         openRouterKeyLast4: settings.openRouterKeyLast4,
@@ -79,6 +91,11 @@ export const useAiStore = create<AiStoreState>((set, get) => ({
   setActiveModel: async (model: string) => {
     set({ activeModel: model });
     await aiApi.updateSettings({ activeModel: model });
+  },
+
+  setAnthropicKey: async (apiKey: string) => {
+    await aiApi.setAnthropicKey({ apiKey });
+    await get().hydrate();
   },
 
   setOpenRouterKey: async (apiKey: string) => {


### PR DESCRIPTION
This PR adds support for configuring an Anthropic API key in the settings, alongside the existing keys.

Changes:
- Backend: Added Anthropic fields to User schema, new DTOs, and Controller endpoints.
- Backend: Added AnthropicClientFactory using @anthropic-ai/sdk.
- Frontend: Added Anthropic API key management in AI Settings.