### PR TITLE
feat(web): add Japandi landing page and components

### DIFF
--- a/packages/mukti-web/src/app/japandi/japandi.css
+++ b/packages/mukti-web/src/app/japandi/japandi.css
@@ -1,0 +1,76 @@
+@theme inline {
+  --color-japandi-cream: #f5f0eb;
+  --color-japandi-stone: #2c2c2b;
+  --color-japandi-terracotta: #c4785b;
+  --color-japandi-sage: #8b9e82;
+  --color-japandi-indigo: #5b6987;
+  --color-japandi-sand: #d4c5b2;
+  --color-japandi-timber: #6b4d3a;
+  --color-japandi-light-stone: #e8e0d6;
+}
+
+.japandi-page {
+  background-color: var(--color-japandi-cream);
+  color: var(--color-japandi-stone);
+  font-family: var(--font-geist-sans), sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.japandi-page ::selection {
+  background-color: var(--color-japandi-sage);
+  color: white;
+}
+
+.text-japandi-heading {
+  font-weight: 300;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+}
+
+.text-japandi-body {
+  font-weight: 400;
+  line-height: 1.8;
+  letter-spacing: 0.01em;
+}
+
+.text-japandi-label {
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.japandi-page ::-webkit-scrollbar {
+  width: 8px;
+}
+
+.japandi-page ::-webkit-scrollbar-track {
+  background: var(--color-japandi-cream);
+}
+
+.japandi-page ::-webkit-scrollbar-thumb {
+  background: var(--color-japandi-sand);
+  border-radius: 4px;
+}
+
+.japandi-page ::-webkit-scrollbar-thumb:hover {
+  background: var(--color-japandi-terracotta);
+}
+
+.bg-grain {
+  position: relative;
+}
+
+.bg-grain::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.05'/%3E%3C/svg%3E");
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.4;
+}

--- a/packages/mukti-web/src/app/japandi/page.tsx
+++ b/packages/mukti-web/src/app/japandi/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import './japandi.css';
+import JapandiCTA from '@/components/japandi/japandi-cta';
+import JapandiFooter from '@/components/japandi/japandi-footer';
+import JapandiHero from '@/components/japandi/japandi-hero';
+import JapandiNav from '@/components/japandi/japandi-nav';
+import JapandiPhilosophy from '@/components/japandi/japandi-philosophy';
+import JapandiPillars from '@/components/japandi/japandi-pillars';
+import JapandiRitual from '@/components/japandi/japandi-ritual';
+import JapandiVoices from '@/components/japandi/japandi-voices';
+
+export default function JapandiPage() {
+  return (
+    <main className="japandi-page bg-grain min-h-screen w-full overflow-x-hidden selection:bg-japandi-sage selection:text-white">
+      <JapandiNav />
+      <JapandiHero />
+      <JapandiPhilosophy />
+      <JapandiPillars />
+      <JapandiRitual />
+      <JapandiVoices />
+      <JapandiCTA />
+      <JapandiFooter />
+    </main>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-cta.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-cta.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useState } from 'react';
+
+export default function JapandiCTA() {
+  const [email, setEmail] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setEmail('');
+  };
+
+  return (
+    <section className="relative w-full px-6 py-24 md:px-12 lg:py-32 bg-japandi-sand/30" id="begin">
+      <div className="max-w-4xl mx-auto text-center">
+        <motion.div
+          className="mb-8"
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, y: 0 }}
+        >
+          <span className="text-japandi-sage text-japandi-label tracking-[0.2em] block mb-6">
+            Begin
+          </span>
+          <h2 className="text-japandi-stone text-4xl md:text-5xl lg:text-6xl font-light tracking-wide leading-tight mb-6">
+            Your practice begins with a single breath
+          </h2>
+          <p className="text-japandi-stone/80 text-lg md:text-xl font-light leading-relaxed max-w-2xl mx-auto mb-12">
+            Start with our free 7-day focus ritual. No credit card. No complexity. Just presence.
+          </p>
+        </motion.div>
+
+        <motion.form
+          className="flex flex-col md:flex-row items-center justify-center gap-4 max-w-md mx-auto"
+          initial={{ opacity: 0, y: 20 }}
+          onSubmit={handleSubmit}
+          transition={{ delay: 0.2, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, y: 0 }}
+        >
+          <input
+            className="w-full md:w-auto flex-1 px-6 py-4 bg-japandi-cream border border-japandi-stone/10 rounded-sm text-japandi-stone placeholder:text-japandi-stone/40 focus:outline-none focus:border-japandi-terracotta transition-colors duration-300"
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Enter your email"
+            required
+            type="email"
+            value={email}
+          />
+          <button
+            className="w-full md:w-auto px-8 py-4 bg-japandi-terracotta text-japandi-cream font-medium tracking-wide rounded-sm hover:bg-japandi-timber transition-colors duration-300 flex items-center justify-center gap-2 group"
+            type="submit"
+          >
+            <span>Begin</span>
+            <ArrowRight className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1" />
+          </button>
+        </motion.form>
+
+        <motion.p
+          className="text-japandi-stone/50 text-sm mt-6"
+          initial={{ opacity: 0 }}
+          transition={{ delay: 0.4, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1 }}
+        >
+          We respect your attention. No spam, ever.
+        </motion.p>
+      </div>
+    </section>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-footer.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-footer.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function JapandiFooter() {
+  return (
+    <footer className="w-full px-6 py-12 md:px-12 bg-japandi-cream border-t border-japandi-sand/20">
+      <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-8">
+        <div className="text-japandi-stone/60 text-sm tracking-widest lowercase">
+          © 2025 komorebi
+        </div>
+
+        <div className="flex items-center gap-8">
+          <Link
+            className="text-japandi-stone/60 hover:text-japandi-terracotta text-sm tracking-widest uppercase transition-colors duration-300"
+            href="#philosophy"
+          >
+            Philosophy
+          </Link>
+          <Link
+            className="text-japandi-stone/60 hover:text-japandi-terracotta text-sm tracking-widest uppercase transition-colors duration-300"
+            href="#practice"
+          >
+            Practice
+          </Link>
+          <Link
+            className="text-japandi-stone/60 hover:text-japandi-terracotta text-sm tracking-widest uppercase transition-colors duration-300"
+            href="#journal"
+          >
+            Journal
+          </Link>
+        </div>
+
+        <div className="text-japandi-stone/40 text-sm tracking-widest">
+          Crafted with <span className="font-normal text-japandi-stone/60">静けさ</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-hero.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-hero.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { motion } from 'motion/react';
+import Link from 'next/link';
+
+export default function JapandiHero() {
+  return (
+    <section className="relative flex min-h-screen w-full flex-col items-center justify-center overflow-hidden px-6 py-24 md:px-12">
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none overflow-hidden">
+        <motion.span
+          animate={{ opacity: 0.08 }}
+          className="text-[20vw] font-thin text-japandi-stone whitespace-nowrap leading-none"
+          initial={{ opacity: 0 }}
+          style={{ writingMode: 'vertical-rl' }}
+          transition={{ duration: 2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          木漏れ日
+        </motion.span>
+      </div>
+
+      <div className="relative z-10 flex max-w-4xl flex-col items-center text-center">
+        <motion.span
+          animate={{ opacity: 1, y: 0 }}
+          className="text-japandi-sage text-japandi-label mb-8 tracking-[0.25em]"
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ delay: 0.2, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          A Mindful Focus Practice
+        </motion.span>
+
+        <motion.h1
+          animate={{ opacity: 1, y: 0 }}
+          className="text-japandi-stone text-5xl md:text-7xl lg:text-8xl font-light tracking-wide mb-8 leading-[1.1]"
+          initial={{ opacity: 0, y: 30 }}
+          transition={{ delay: 0.4, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          Where deep work
+          <br />
+          meets deep calm
+        </motion.h1>
+
+        <motion.p
+          animate={{ opacity: 1, y: 0 }}
+          className="text-japandi-stone/80 text-lg md:text-xl max-w-xl mb-12 font-light leading-relaxed"
+          initial={{ opacity: 0, y: 30 }}
+          transition={{ delay: 0.6, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          Design intentional focus rituals that honor both productivity and presence.
+        </motion.p>
+
+        <motion.div
+          animate={{ opacity: 1, y: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ delay: 0.8, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          <Link
+            className="group flex items-center gap-2 text-japandi-terracotta text-lg tracking-widest hover:text-japandi-stone transition-colors duration-500"
+            href="#philosophy"
+          >
+            <span>Discover the practice</span>
+            <ArrowRight className="w-4 h-4 transition-transform duration-500 group-hover:translate-x-1" />
+          </Link>
+        </motion.div>
+      </div>
+
+      <motion.div
+        animate={{ opacity: 1, width: '100%' }}
+        className="absolute bottom-24 left-0 right-0 flex items-center justify-center"
+        initial={{ opacity: 0, width: 0 }}
+        transition={{ delay: 1.2, duration: 1.5, ease: [0.25, 0.1, 0.25, 1] }}
+      >
+        <div className="h-[1px] w-full max-w-xs bg-japandi-sand/50 relative">
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-2 h-2 rounded-full border border-japandi-sand bg-japandi-cream" />
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-nav.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-nav.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'motion/react';
+import Link from 'next/link';
+
+import { cn } from '@/lib/utils';
+
+export default function JapandiNav() {
+  const { scrollY } = useScroll();
+
+  const backgroundColor = useTransform(
+    scrollY,
+    [0, 50],
+    ['rgba(245, 240, 235, 0)', 'rgba(245, 240, 235, 0.95)']
+  );
+
+  const backdropFilter = useTransform(scrollY, [0, 50], ['blur(0px)', 'blur(8px)']);
+
+  const borderBottomColor = useTransform(
+    scrollY,
+    [0, 50],
+    ['rgba(212, 197, 178, 0)', 'rgba(212, 197, 178, 0.3)']
+  );
+
+  return (
+    <motion.nav
+      className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 md:px-12 md:py-6 transition-all duration-500"
+      style={{
+        backdropFilter,
+        backgroundColor,
+        borderBottom: '1px solid',
+        borderBottomColor,
+      }}
+    >
+      <Link className="group" href="/japandi">
+        <span className="text-japandi-stone text-xl font-light tracking-[0.15em] lowercase opacity-90 group-hover:opacity-100 transition-opacity">
+          komorebi
+        </span>
+      </Link>
+
+      <Link
+        className={cn(
+          'text-japandi-stone text-sm tracking-widest uppercase hover:text-japandi-terracotta transition-colors duration-300',
+          "relative after:content-[''] after:absolute after:bottom-[-4px] after:left-0 after:w-0 after:h-[1px] after:bg-japandi-terracotta after:transition-all after:duration-300 hover:after:w-full"
+        )}
+        href="#begin"
+      >
+        Begin your practice
+      </Link>
+    </motion.nav>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-philosophy.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-philosophy.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { motion } from 'motion/react';
+
+export default function JapandiPhilosophy() {
+  return (
+    <section
+      className="relative w-full px-6 py-24 md:px-12 lg:py-32 bg-japandi-cream"
+      id="philosophy"
+    >
+      <div className="max-w-6xl mx-auto">
+        <motion.div
+          className="mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, y: 0 }}
+        >
+          <span className="text-japandi-sage text-japandi-label block mb-4">Philosophy</span>
+          <h2 className="text-japandi-stone text-4xl md:text-5xl lg:text-6xl font-light tracking-wide leading-tight">
+            Not another productivity tool
+          </h2>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-24">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            transition={{ delay: 0.2, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+            viewport={{ once: true }}
+            whileInView={{ opacity: 1, y: 0 }}
+          >
+            <p className="text-japandi-stone/90 text-xl md:text-2xl font-light leading-relaxed">
+              We believe the modern obsession with output has cost us something precious — the
+              quality of our attention. Komorebi exists to restore that.
+            </p>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            transition={{ delay: 0.4, duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+            viewport={{ once: true }}
+            whileInView={{ opacity: 1, y: 0 }}
+          >
+            <p className="text-japandi-stone/80 text-lg md:text-xl font-light leading-relaxed">
+              Inspired by the Japanese concept of <span className="italic">間 (ma)</span> — the
+              meaningful pause — and the Scandinavian ideal of <span className="italic">lagom</span>{' '}
+              — just enough — we&apos;ve created a practice that makes space for both focus and
+              stillness.
+            </p>
+          </motion.div>
+        </div>
+
+        <motion.div
+          className="mt-24 w-full h-[1px] bg-japandi-sand/40 origin-left"
+          initial={{ opacity: 0, scaleX: 0 }}
+          transition={{ delay: 0.6, duration: 1.5, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, scaleX: 1 }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-pillars.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-pillars.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { motion } from 'motion/react';
+
+const pillars = [
+  {
+    decoration: (
+      <svg
+        className="w-12 h-12 text-japandi-sage/30"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        viewBox="0 0 100 100"
+      >
+        <circle cx="50" cy="50" r="40" />
+        <circle cx="50" cy="50" r="20" />
+      </svg>
+    ),
+    description:
+      'Curated ambient soundscapes and visual environments that settle the mind — from misty forest mornings to rain on timber rooftops.',
+    english: 'Stillness',
+    id: '01',
+    japanese: '静けさ',
+    romanized: 'Shizukesa',
+  },
+  {
+    decoration: (
+      <svg
+        className="w-12 h-12 text-japandi-terracotta/30"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        viewBox="0 0 100 100"
+      >
+        <rect height="60" width="60" x="20" y="20" />
+        <line x1="20" x2="80" y1="50" y2="50" />
+      </svg>
+    ),
+    description:
+      'Structured focus rituals with gentle time blocks, rest intervals, and natural transitions — work that breathes.',
+    english: 'Form',
+    id: '02',
+    japanese: '形',
+    romanized: 'Katachi',
+  },
+  {
+    decoration: (
+      <svg
+        className="w-12 h-12 text-japandi-indigo/30"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        viewBox="0 0 100 100"
+      >
+        <path d="M20 80 C 20 20, 80 20, 80 80" />
+        <path d="M35 80 C 35 40, 65 40, 65 80" />
+      </svg>
+    ),
+    description:
+      'End-of-session journaling prompts that transform productivity into self-knowledge.',
+    english: 'Reflection',
+    id: '03',
+    japanese: '振り返り',
+    romanized: 'Furikaeri',
+  },
+];
+
+export default function JapandiPillars() {
+  return (
+    <section className="relative w-full px-6 py-24 md:px-12 lg:py-32 bg-japandi-cream">
+      <div className="max-w-7xl mx-auto">
+        <motion.div
+          className="mb-16 text-center md:text-left"
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, y: 0 }}
+        >
+          <span className="text-japandi-sage text-japandi-label tracking-[0.2em]">
+            The Practice
+          </span>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 lg:gap-12">
+          {pillars.map((pillar, index) => (
+            <motion.div
+              className="group relative flex flex-col p-8 md:p-10 bg-japandi-light-stone/40 rounded-sm hover:bg-japandi-light-stone/60 transition-colors duration-700"
+              initial={{ opacity: 0, y: 40 }}
+              key={pillar.id}
+              transition={{
+                delay: index * 0.2,
+                duration: 1.2,
+                ease: [0.25, 0.1, 0.25, 1],
+              }}
+              viewport={{ once: true }}
+              whileInView={{ opacity: 1, y: 0 }}
+            >
+              <div className="absolute top-8 right-8 opacity-50 group-hover:opacity-100 transition-opacity duration-700">
+                {pillar.decoration}
+              </div>
+
+              <span className="text-japandi-sand text-6xl font-thin mb-8 block opacity-40">
+                {pillar.id}
+              </span>
+
+              <div className="mb-6">
+                <h3 className="text-japandi-stone text-2xl font-light mb-1">{pillar.japanese}</h3>
+                <span className="text-japandi-sage text-sm uppercase tracking-widest block mb-2">
+                  {pillar.romanized}
+                </span>
+                <h4 className="text-japandi-stone text-xl font-normal">{pillar.english}</h4>
+              </div>
+
+              <p className="text-japandi-stone/80 text-base leading-relaxed font-light mt-auto">
+                {pillar.description}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-ritual.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-ritual.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { motion } from 'motion/react';
+
+import { cn } from '@/lib/utils';
+
+const steps = [
+  {
+    description: 'Arrive. Set an intention for your session.',
+    icon: (
+      <svg
+        className="w-6 h-6 text-japandi-sage"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        viewBox="0 0 24 24"
+      >
+        <circle cx="12" cy="12" r="5" />
+        <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+      </svg>
+    ),
+    time: '~5 min',
+    title: 'Morning',
+  },
+  {
+    description: 'Enter your soundscape. Begin your time block.',
+    icon: (
+      <svg
+        className="w-6 h-6 text-japandi-terracotta"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        viewBox="0 0 24 24"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    ),
+    time: '25-50 min',
+    title: 'Focus',
+  },
+  {
+    description: 'The bell sounds. Step away. Breathe.',
+    icon: (
+      <svg
+        className="w-6 h-6 text-japandi-indigo"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        viewBox="0 0 24 24"
+      >
+        <path d="M18 8a6 6 0 0 0-6-6 6 6 0 0 0-6 6c0 7 3 9 3 9h6s3-2 3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      </svg>
+    ),
+    time: '5-10 min',
+    title: 'Rest',
+  },
+  {
+    description: 'Journal what surfaced. Close with gratitude.',
+    icon: (
+      <svg
+        className="w-6 h-6 text-japandi-timber"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        viewBox="0 0 24 24"
+      >
+        <path d="M12 20h9" />
+        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+      </svg>
+    ),
+    time: '~5 min',
+    title: 'Reflect',
+  },
+];
+
+export default function JapandiRitual() {
+  return (
+    <section className="relative w-full px-6 py-24 md:px-12 lg:py-32 bg-japandi-cream overflow-hidden">
+      <div className="max-w-4xl mx-auto">
+        <motion.div
+          className="mb-24 text-center"
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, y: 0 }}
+        >
+          <h2 className="text-japandi-stone text-4xl md:text-5xl font-light tracking-wide mb-4">
+            A day with Komorebi
+          </h2>
+          <p className="text-japandi-stone/60 text-lg font-light">
+            The rhythm of a mindful practice
+          </p>
+        </motion.div>
+
+        <div className="relative">
+          <div className="absolute left-[27px] md:left-1/2 top-0 bottom-0 w-[1px] bg-japandi-sand/30 -translate-x-1/2" />
+
+          <motion.div
+            className="absolute left-[27px] md:left-1/2 top-0 w-[1px] bg-japandi-terracotta/50 -translate-x-1/2 origin-top"
+            initial={{ height: 0 }}
+            transition={{ duration: 2.5, ease: [0.25, 0.1, 0.25, 1] }}
+            viewport={{ once: true }}
+            whileInView={{ height: '100%' }}
+          />
+
+          <div className="space-y-16 md:space-y-24">
+            {steps.map((step, index) => (
+              <motion.div
+                className={cn(
+                  'relative flex items-center gap-8 md:gap-16',
+                  index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'
+                )}
+                initial={{ opacity: 0, y: 30 }}
+                key={index}
+                transition={{
+                  delay: index * 0.3,
+                  duration: 1.2,
+                  ease: [0.25, 0.1, 0.25, 1],
+                }}
+                viewport={{ once: true }}
+                whileInView={{ opacity: 1, y: 0 }}
+              >
+                <div
+                  className={cn('hidden md:block w-1/2 text-right', index % 2 !== 0 && 'text-left')}
+                >
+                  <span className="text-japandi-sage text-sm uppercase tracking-widest font-medium">
+                    {step.time}
+                  </span>
+                </div>
+
+                <div className="relative z-10 flex-shrink-0 w-14 h-14 rounded-full bg-japandi-cream border border-japandi-sand flex items-center justify-center shadow-sm">
+                  {step.icon}
+                </div>
+
+                <div className="flex-1 md:w-1/2 pt-2 md:pt-0">
+                  <div className="md:hidden mb-2">
+                    <span className="text-japandi-sage text-xs uppercase tracking-widest font-medium">
+                      {step.time}
+                    </span>
+                  </div>
+                  <h3 className="text-japandi-stone text-xl font-normal mb-2">{step.title}</h3>
+                  <p className="text-japandi-stone/70 text-base font-light leading-relaxed">
+                    {step.description}
+                  </p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/mukti-web/src/components/japandi/japandi-voices.tsx
+++ b/packages/mukti-web/src/components/japandi/japandi-voices.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { motion } from 'motion/react';
+
+const testimonials = [
+  {
+    author: 'Linnea K.',
+    location: 'Stockholm',
+    quote:
+      "Komorebi didn't make me more productive. It made me more present. The work followed naturally.",
+    role: 'Architect',
+  },
+  {
+    author: 'Yuki T.',
+    location: 'Kyoto',
+    quote:
+      'I used to measure my days in tasks completed. Now I measure them in moments of genuine focus.',
+    role: 'Writer',
+  },
+  {
+    author: 'Maren H.',
+    location: 'Copenhagen',
+    quote:
+      'The silence between sessions taught me more about my creative process than any productivity system ever did.',
+    role: 'Designer',
+  },
+];
+
+export default function JapandiVoices() {
+  return (
+    <section className="relative w-full px-6 py-24 md:px-12 lg:py-32 bg-japandi-cream">
+      <div className="max-w-7xl mx-auto">
+        <motion.div
+          className="mb-16 text-center"
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ duration: 1.2, ease: [0.25, 0.1, 0.25, 1] }}
+          viewport={{ once: true }}
+          whileInView={{ opacity: 1, y: 0 }}
+        >
+          <span className="text-japandi-sage text-japandi-label tracking-[0.2em]">Voices</span>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 lg:gap-12">
+          {testimonials.map((testimonial, index) => (
+            <motion.div
+              className="flex flex-col items-center text-center p-6"
+              initial={{ opacity: 0, y: 30 }}
+              key={index}
+              transition={{
+                delay: index * 0.2,
+                duration: 1.2,
+                ease: [0.25, 0.1, 0.25, 1],
+              }}
+              viewport={{ once: true }}
+              whileInView={{ opacity: 1, y: 0 }}
+            >
+              <span className="text-japandi-terracotta text-6xl font-serif leading-none mb-6 opacity-80">
+                &ldquo;
+              </span>
+
+              <p className="text-japandi-stone text-lg md:text-xl font-light italic leading-relaxed mb-8">
+                {testimonial.quote}
+              </p>
+
+              <div className="mt-auto">
+                <p className="text-japandi-stone font-medium tracking-wide">{testimonial.author}</p>
+                <p className="text-japandi-stone/60 text-sm mt-1">
+                  {testimonial.role}, {testimonial.location}
+                </p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Implement a minimalist Japandi-themed landing page featuring custom components for navigation, hero, philosophy, and rituals. Also adds an animated Mukti logo component.

## Description
<!--Brief summary of what this PR does and why.-->

## Changes
<!--
- List the main changes made
- Keep it concise and focused
- Use bullet points for clarity
-->
## Testing
<!--How was this tested? What scenarios were covered?-->

## Screenshots (if applicable)
<!--Add screenshots or recordings if there are UI changes.-->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or documented if any)

## Additional Notes
<!--Any extra context, concerns, or areas needing special review.-->
