### PR TITLE
feat(api,web): Backend-only AI provider configuration and usage cost tracking

### DIFF
--- a/packages/mukti-api/src/modules/ai/ai.module.ts
+++ b/packages/mukti-api/src/modules/ai/ai.module.ts
@@ -2,18 +2,35 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 
+import {
+  AiModelConfig,
+  AiModelConfigSchema,
+} from '../../schemas/ai-model-config.schema';
+import {
+  AiProviderConfig,
+  AiProviderConfigSchema,
+} from '../../schemas/ai-provider-config.schema';
 import { User, UserSchema } from '../../schemas/user.schema';
+import { AuthModule } from '../auth/auth.module';
 import { AiController } from './ai.controller';
 import { AiPolicyService } from './services/ai-policy.service';
+import { AiConfigService } from './services/ai-config.service';
+import { AiGatewayService } from './services/ai-gateway.service';
 import { AiSecretsService } from './services/ai-secrets.service';
 import { GeminiClientFactory } from './services/gemini-client.factory';
 import { OpenRouterClientFactory } from './services/openrouter-client.factory';
 import { OpenRouterModelsService } from './services/openrouter-models.service';
+import { AnthropicProviderService } from './services/providers/anthropic-provider.service';
+import { GeminiProviderService } from './services/providers/gemini-provider.service';
+import { OpenAiProviderService } from './services/providers/openai-provider.service';
+import { OpenRouterProviderService } from './services/providers/openrouter-provider.service';
 
 @Module({
   controllers: [AiController],
   exports: [
     AiPolicyService,
+    AiConfigService,
+    AiGatewayService,
     AiSecretsService,
     GeminiClientFactory,
     OpenRouterClientFactory,
@@ -21,14 +38,25 @@ import { OpenRouterModelsService } from './services/openrouter-models.service';
   ],
   imports: [
     ConfigModule,
-    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    AuthModule,
+    MongooseModule.forFeature([
+      { name: User.name, schema: UserSchema },
+      { name: AiProviderConfig.name, schema: AiProviderConfigSchema },
+      { name: AiModelConfig.name, schema: AiModelConfigSchema },
+    ]),
   ],
   providers: [
     AiPolicyService,
+    AiConfigService,
+    AiGatewayService,
     AiSecretsService,
     GeminiClientFactory,
     OpenRouterClientFactory,
     OpenRouterModelsService,
+    OpenAiProviderService,
+    AnthropicProviderService,
+    GeminiProviderService,
+    OpenRouterProviderService,
   ],
 })
 export class AiModule {}

--- a/packages/mukti-api/src/modules/ai/dto/admin-model.dto.ts
+++ b/packages/mukti-api/src/modules/ai/dto/admin-model.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsIn,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+import { AI_PROVIDER_VALUES } from '../../../schemas/ai-provider-config.schema';
+
+export class AiModelPricingDto {
+  @ApiProperty({
+    description: 'Prompt price in USD per 1M input tokens',
+    example: 0.15,
+  })
+  @IsNumber()
+  @Min(0)
+  promptUsdPer1M: number;
+
+  @ApiProperty({
+    description: 'Completion price in USD per 1M output tokens',
+    example: 0.6,
+  })
+  @IsNumber()
+  @Min(0)
+  completionUsdPer1M: number;
+}
+
+export class UpsertAiModelDto {
+  @ApiProperty({
+    description: 'Client-facing model label',
+    example: 'GPT-4.1 Mini',
+  })
+  @IsNotEmpty()
+  @IsString()
+  label: string;
+
+  @ApiProperty({
+    description: 'Provider for this model',
+    enum: AI_PROVIDER_VALUES,
+    example: 'openai',
+  })
+  @IsIn(AI_PROVIDER_VALUES)
+  provider: string;
+
+  @ApiProperty({
+    description: 'Provider-specific model identifier',
+    example: 'gpt-4.1-mini',
+  })
+  @IsNotEmpty()
+  @IsString()
+  providerModel: string;
+
+  @ApiProperty({
+    description: 'Pricing configuration for deterministic cost tracking',
+    type: AiModelPricingDto,
+  })
+  @Type(() => AiModelPricingDto)
+  @ValidateNested()
+  pricing: AiModelPricingDto;
+
+  @ApiPropertyOptional({
+    description: 'Whether this model is available to users',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}
+
+export class ToggleAiModelDto {
+  @ApiProperty({
+    description: 'Whether this model is active',
+    example: true,
+  })
+  @IsBoolean()
+  isActive: boolean;
+}

--- a/packages/mukti-api/src/modules/ai/dto/admin-provider.dto.ts
+++ b/packages/mukti-api/src/modules/ai/dto/admin-provider.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+
+export class SetProviderApiKeyDto {
+  @ApiProperty({
+    description: 'Provider API key to store on the server',
+    example: 'sk-...',
+  })
+  @IsNotEmpty()
+  @IsString()
+  apiKey: string;
+}
+
+export class ToggleProviderDto {
+  @ApiProperty({
+    description: 'Whether this provider is active for model routing',
+    example: true,
+  })
+  @IsBoolean()
+  isActive: boolean;
+}

--- a/packages/mukti-api/src/modules/ai/dto/ai-settings.dto.ts
+++ b/packages/mukti-api/src/modules/ai/dto/ai-settings.dto.ts
@@ -3,8 +3,8 @@ import { IsOptional, IsString } from 'class-validator';
 
 export class UpdateAiSettingsDto {
   @ApiPropertyOptional({
-    description: 'Globally active OpenRouter model id',
-    example: 'openai/gpt-5-mini',
+    description: 'Globally active AI model id',
+    example: 'default-gpt-5-mini',
   })
   @IsOptional()
   @IsString()

--- a/packages/mukti-api/src/modules/ai/services/__tests__/ai-config.service.spec.ts
+++ b/packages/mukti-api/src/modules/ai/services/__tests__/ai-config.service.spec.ts
@@ -1,0 +1,222 @@
+import { BadRequestException } from '@nestjs/common';
+
+import type { AiModelConfig } from '../../../../schemas/ai-model-config.schema';
+import type { AiProviderConfig } from '../../../../schemas/ai-provider-config.schema';
+
+import { AiConfigService } from '../ai-config.service';
+
+describe('AiConfigService', () => {
+  let service: AiConfigService;
+
+  let providerDocs: Partial<AiProviderConfig>[];
+  let modelDocs: Partial<AiModelConfig>[];
+
+  beforeEach(() => {
+    providerDocs = [];
+    modelDocs = [];
+
+    const providerModel = {
+      find: jest.fn((filter: any = {}) => ({
+        select: jest.fn(() => ({
+          lean: jest.fn(async () =>
+            providerDocs.filter((doc) => {
+              if (
+                filter.isActive !== undefined &&
+                doc.isActive !== filter.isActive
+              ) {
+                return false;
+              }
+
+              if (filter.provider && doc.provider !== filter.provider) {
+                return false;
+              }
+
+              return true;
+            }),
+          ),
+        })),
+      })),
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    const aiModelModel = {
+      find: jest.fn((filter: any = {}) => ({
+        sort: jest.fn(() => ({
+          lean: jest.fn(async () =>
+            modelDocs
+              .filter((doc) => {
+                if (
+                  filter.isActive !== undefined &&
+                  doc.isActive !== filter.isActive
+                ) {
+                  return false;
+                }
+
+                if (filter.id && doc.id !== filter.id) {
+                  return false;
+                }
+
+                if (
+                  filter.provider?.$in &&
+                  Array.isArray(filter.provider.$in) &&
+                  !filter.provider.$in.includes(doc.provider)
+                ) {
+                  return false;
+                }
+
+                return true;
+              })
+              .sort((a, b) => (a.id ?? '').localeCompare(b.id ?? '')),
+          ),
+        })),
+      })),
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    const aiSecretsService = {
+      decryptString: jest.fn(),
+      encryptString: jest.fn(),
+    };
+
+    service = new AiConfigService(
+      providerModel as any,
+      aiModelModel as any,
+      aiSecretsService as any,
+    );
+  });
+
+  it('should return only models that are active and mapped to active providers with keys', async () => {
+    providerDocs = [
+      {
+        apiKeyEncrypted: 'enc-openai',
+        isActive: true,
+        provider: 'openai',
+      },
+      {
+        apiKeyEncrypted: 'enc-anthropic',
+        isActive: false,
+        provider: 'anthropic',
+      },
+      {
+        isActive: true,
+        provider: 'gemini',
+      },
+    ];
+
+    modelDocs = [
+      {
+        id: 'openai/gpt-5-mini',
+        isActive: true,
+        label: 'GPT-5 Mini',
+        pricing: { completionUsdPer1M: 0.4, promptUsdPer1M: 0.1 },
+        provider: 'openai',
+        providerModel: 'gpt-5-mini',
+      },
+      {
+        id: 'anthropic/claude-sonnet',
+        isActive: true,
+        label: 'Claude Sonnet',
+        pricing: { completionUsdPer1M: 1.0, promptUsdPer1M: 0.3 },
+        provider: 'anthropic',
+        providerModel: 'claude-sonnet-4-20250514',
+      },
+      {
+        id: 'openai/gpt-5-mini-inactive',
+        isActive: false,
+        label: 'GPT-5 Mini Inactive',
+        pricing: { completionUsdPer1M: 0.4, promptUsdPer1M: 0.1 },
+        provider: 'openai',
+        providerModel: 'gpt-5-mini',
+      },
+      {
+        id: 'gemini/gemini-2.0-flash',
+        isActive: true,
+        label: 'Gemini 2.0 Flash',
+        pricing: { completionUsdPer1M: 0.3, promptUsdPer1M: 0.075 },
+        provider: 'gemini',
+        providerModel: 'gemini-2.0-flash',
+      },
+    ];
+
+    const models = await service.getClientModels();
+
+    expect(models).toEqual([
+      {
+        id: 'openai/gpt-5-mini',
+        label: 'GPT-5 Mini',
+      },
+    ]);
+  });
+
+  it('should throw MODEL_NOT_ALLOWED when requested model is not active/allowed', async () => {
+    providerDocs = [
+      {
+        apiKeyEncrypted: 'enc-openai',
+        isActive: true,
+        provider: 'openai',
+      },
+    ];
+
+    modelDocs = [
+      {
+        id: 'openai/gpt-5-mini',
+        isActive: true,
+        label: 'GPT-5 Mini',
+        pricing: { completionUsdPer1M: 0.4, promptUsdPer1M: 0.1 },
+        provider: 'openai',
+        providerModel: 'gpt-5-mini',
+      },
+    ];
+
+    await expect(
+      service.resolveModelSelection({
+        requestedModel: 'gemini/gemini-2.0-flash',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    await expect(
+      service.resolveModelSelection({
+        requestedModel: 'gemini/gemini-2.0-flash',
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        error: {
+          code: 'MODEL_NOT_ALLOWED',
+        },
+      },
+    });
+  });
+
+  it('should fall back to a default active model when user preference is invalid', async () => {
+    providerDocs = [
+      {
+        apiKeyEncrypted: 'enc-openai',
+        isActive: true,
+        provider: 'openai',
+      },
+    ];
+
+    modelDocs = [
+      {
+        id: 'openai/gpt-5-mini',
+        isActive: true,
+        label: 'GPT-5 Mini',
+        pricing: { completionUsdPer1M: 0.4, promptUsdPer1M: 0.1 },
+        provider: 'openai',
+        providerModel: 'gpt-5-mini',
+      },
+    ];
+
+    const result = await service.resolveModelSelection({
+      userActiveModel: 'legacy/inactive-model',
+    });
+
+    expect(result).toEqual({
+      activeModel: 'openai/gpt-5-mini',
+      aiConfigured: true,
+      shouldPersist: true,
+    });
+  });
+});

--- a/packages/mukti-api/src/modules/ai/services/__tests__/ai-cost.service.spec.ts
+++ b/packages/mukti-api/src/modules/ai/services/__tests__/ai-cost.service.spec.ts
@@ -1,0 +1,16 @@
+import { calculateAiCostUsd } from '../ai-cost.service';
+
+describe('calculateAiCostUsd', () => {
+  it('should calculate deterministic cost from prompt and completion pricing', () => {
+    const cost = calculateAiCostUsd({
+      completionTokens: 1_500,
+      pricing: {
+        completionUsdPer1M: 0.6,
+        promptUsdPer1M: 0.15,
+      },
+      promptTokens: 2_500,
+    });
+
+    expect(cost).toBeCloseTo(0.001275, 10);
+  });
+});

--- a/packages/mukti-api/src/modules/ai/services/ai-config.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/ai-config.service.ts
@@ -1,0 +1,459 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import {
+  AI_PROVIDER_VALUES,
+  type AiProvider,
+  AiProviderConfig,
+  type AiProviderConfigDocument,
+} from '../../../schemas/ai-provider-config.schema';
+import {
+  AiModelConfig,
+  type AiModelConfigDocument,
+  type AiModelPricing,
+} from '../../../schemas/ai-model-config.schema';
+
+import { AiSecretsService } from './ai-secrets.service';
+
+export interface AdminProviderView {
+  apiKeyLast4: null | string;
+  isActive: boolean;
+  provider: AiProvider;
+  updatedAt: Date | null;
+}
+
+export interface AdminModelView {
+  id: string;
+  isActive: boolean;
+  label: string;
+  pricing: AiModelPricing;
+  provider: AiProvider;
+  providerModel: string;
+  updatedAt?: Date;
+}
+
+export interface AiClientModel {
+  id: string;
+  label: string;
+}
+
+export interface AiModelSelectionResult {
+  activeModel: null | string;
+  aiConfigured: boolean;
+  shouldPersist: boolean;
+}
+
+export interface AiGatewayModelConfig {
+  apiKey: string;
+  id: string;
+  pricing: AiModelPricing;
+  provider: AiProvider;
+  providerModel: string;
+}
+
+interface UpsertModelInput {
+  isActive?: boolean;
+  label: string;
+  pricing: AiModelPricing;
+  provider: string;
+  providerModel: string;
+}
+
+@Injectable()
+export class AiConfigService {
+  constructor(
+    @InjectModel(AiProviderConfig.name)
+    private readonly aiProviderConfigModel: Model<AiProviderConfigDocument>,
+    @InjectModel(AiModelConfig.name)
+    private readonly aiModelConfigModel: Model<AiModelConfigDocument>,
+    private readonly aiSecretsService: AiSecretsService,
+  ) {}
+
+  async deleteModelConfig(idInput: string): Promise<void> {
+    const id = this.normalizeModelId(idInput);
+
+    await this.aiModelConfigModel.deleteOne({ id });
+  }
+
+  async getAdminModels(): Promise<AdminModelView[]> {
+    const docs = await this.aiModelConfigModel
+      .find()
+      .sort({ label: 1, id: 1 })
+      .lean();
+
+    return docs.map((doc) => this.toAdminModelView(doc));
+  }
+
+  async getAdminProviders(): Promise<AdminProviderView[]> {
+    const docs = await this.aiProviderConfigModel
+      .find()
+      .select('provider isActive apiKeyLast4 updatedAt')
+      .lean();
+
+    const providerMap = new Map<AiProvider, (typeof docs)[number]>();
+    for (const doc of docs) {
+      providerMap.set(doc.provider, doc);
+    }
+
+    return AI_PROVIDER_VALUES.map((provider) => {
+      const doc = providerMap.get(provider);
+
+      return {
+        apiKeyLast4: doc?.apiKeyLast4 ?? null,
+        isActive: doc?.isActive ?? false,
+        provider,
+        updatedAt: doc?.updatedAt ?? null,
+      };
+    });
+  }
+
+  async getClientModels(): Promise<AiClientModel[]> {
+    const models = await this.getActiveUsableModels();
+    return models.map((model) => ({ id: model.id, label: model.label }));
+  }
+
+  async getModelForGeneration(
+    modelIdInput: string,
+  ): Promise<AiGatewayModelConfig> {
+    const modelId = this.normalizeModelId(modelIdInput);
+
+    const modelConfig = await this.aiModelConfigModel
+      .findOne({ id: modelId, isActive: true })
+      .lean();
+
+    if (!modelConfig) {
+      this.throwModelNotAllowed();
+    }
+
+    const providerConfig = await this.aiProviderConfigModel
+      .findOne({
+        isActive: true,
+        provider: modelConfig.provider,
+      })
+      .select('+apiKeyEncrypted provider')
+      .lean();
+
+    if (!providerConfig) {
+      this.throwModelNotAllowed();
+    }
+
+    if (!providerConfig.apiKeyEncrypted) {
+      throw new BadRequestException({
+        error: {
+          code: 'AI_PROVIDER_NOT_CONFIGURED',
+          message: `${providerConfig.provider} provider is active but has no configured key`,
+        },
+      });
+    }
+
+    return {
+      apiKey: this.aiSecretsService.decryptString(
+        providerConfig.apiKeyEncrypted,
+      ),
+      id: modelConfig.id,
+      pricing: modelConfig.pricing,
+      provider: modelConfig.provider,
+      providerModel: modelConfig.providerModel,
+    };
+  }
+
+  async resolveModelSelection(params: {
+    requestedModel?: null | string;
+    userActiveModel?: null | string;
+  }): Promise<AiModelSelectionResult> {
+    const usableModels = await this.getActiveUsableModels();
+
+    if (usableModels.length === 0) {
+      return {
+        activeModel: null,
+        aiConfigured: false,
+        shouldPersist: !!params.userActiveModel,
+      };
+    }
+
+    const allowedModelIds = new Set(usableModels.map((model) => model.id));
+
+    const requested = params.requestedModel?.trim();
+    if (requested) {
+      if (!allowedModelIds.has(requested)) {
+        this.throwModelNotAllowed();
+      }
+
+      return {
+        activeModel: requested,
+        aiConfigured: true,
+        shouldPersist: requested !== params.userActiveModel,
+      };
+    }
+
+    const existing = params.userActiveModel?.trim();
+    if (existing && allowedModelIds.has(existing)) {
+      return {
+        activeModel: existing,
+        aiConfigured: true,
+        shouldPersist: false,
+      };
+    }
+
+    const fallback = usableModels[0].id;
+
+    return {
+      activeModel: fallback,
+      aiConfigured: true,
+      shouldPersist: fallback !== existing,
+    };
+  }
+
+  async setModelActive(
+    idInput: string,
+    isActive: boolean,
+  ): Promise<AdminModelView> {
+    const id = this.normalizeModelId(idInput);
+
+    const updated = await this.aiModelConfigModel
+      .findOneAndUpdate(
+        { id },
+        {
+          $set: {
+            isActive,
+          },
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      )
+      .lean();
+
+    if (!updated) {
+      throw new NotFoundException(`Model '${id}' not found`);
+    }
+
+    return this.toAdminModelView(updated);
+  }
+
+  async setProviderActive(
+    providerInput: string,
+    isActive: boolean,
+  ): Promise<AdminProviderView> {
+    const provider = this.normalizeProvider(providerInput);
+
+    const updated = await this.aiProviderConfigModel
+      .findOneAndUpdate(
+        { provider },
+        {
+          $set: {
+            isActive,
+            provider,
+          },
+        },
+        {
+          new: true,
+          runValidators: true,
+          setDefaultsOnInsert: true,
+          upsert: true,
+        },
+      )
+      .select('provider isActive apiKeyLast4 updatedAt')
+      .lean();
+
+    return {
+      apiKeyLast4: updated?.apiKeyLast4 ?? null,
+      isActive: updated?.isActive ?? false,
+      provider,
+      updatedAt: updated?.updatedAt ?? null,
+    };
+  }
+
+  async setProviderApiKey(
+    providerInput: string,
+    apiKeyInput: string,
+  ): Promise<AdminProviderView> {
+    const provider = this.normalizeProvider(providerInput);
+    const apiKey = apiKeyInput.trim();
+
+    if (!apiKey) {
+      throw new BadRequestException({
+        error: {
+          code: 'INVALID_API_KEY',
+          message: 'API key is required',
+        },
+      });
+    }
+
+    const encrypted = this.aiSecretsService.encryptString(apiKey);
+    const last4 = apiKey.slice(-4);
+
+    const updated = await this.aiProviderConfigModel
+      .findOneAndUpdate(
+        { provider },
+        {
+          $set: {
+            apiKeyEncrypted: encrypted,
+            apiKeyLast4: last4,
+            provider,
+            updatedAt: new Date(),
+          },
+        },
+        {
+          new: true,
+          runValidators: true,
+          setDefaultsOnInsert: true,
+          upsert: true,
+        },
+      )
+      .select('provider isActive apiKeyLast4 updatedAt')
+      .lean();
+
+    return {
+      apiKeyLast4: updated?.apiKeyLast4 ?? null,
+      isActive: updated?.isActive ?? false,
+      provider,
+      updatedAt: updated?.updatedAt ?? null,
+    };
+  }
+
+  async upsertModelConfig(
+    idInput: string,
+    dto: UpsertModelInput,
+  ): Promise<AdminModelView> {
+    const id = this.normalizeModelId(idInput);
+    const provider = this.normalizeProvider(dto.provider);
+
+    const updated = await this.aiModelConfigModel
+      .findOneAndUpdate(
+        { id },
+        {
+          $set: {
+            id,
+            isActive: dto.isActive ?? true,
+            label: dto.label.trim(),
+            pricing: {
+              completionUsdPer1M: dto.pricing.completionUsdPer1M,
+              promptUsdPer1M: dto.pricing.promptUsdPer1M,
+            },
+            provider,
+            providerModel: dto.providerModel.trim(),
+          },
+        },
+        {
+          new: true,
+          runValidators: true,
+          setDefaultsOnInsert: true,
+          upsert: true,
+        },
+      )
+      .lean();
+
+    return this.toAdminModelView(updated!);
+  }
+
+  private async getActiveUsableModels(): Promise<
+    {
+      id: string;
+      label: string;
+      pricing: AiModelPricing;
+      provider: AiProvider;
+      providerModel: string;
+    }[]
+  > {
+    const activeProviders = await this.aiProviderConfigModel
+      .find({
+        isActive: true,
+      })
+      .select('+apiKeyEncrypted provider')
+      .lean();
+
+    const providersWithKeys = activeProviders
+      .filter((providerConfig) => !!providerConfig.apiKeyEncrypted)
+      .map((providerConfig) => providerConfig.provider);
+
+    if (providersWithKeys.length === 0) {
+      return [];
+    }
+
+    const models = await this.aiModelConfigModel
+      .find({
+        isActive: true,
+        provider: { $in: providersWithKeys },
+      })
+      .sort({ id: 1, label: 1 })
+      .lean();
+
+    return models.map((model) => ({
+      id: model.id,
+      label: model.label,
+      pricing: model.pricing,
+      provider: model.provider,
+      providerModel: model.providerModel,
+    }));
+  }
+
+  private normalizeModelId(modelId: string): string {
+    const normalized = modelId.trim();
+
+    if (!normalized) {
+      throw new BadRequestException({
+        error: {
+          code: 'INVALID_MODEL_ID',
+          message: 'Model id is required',
+        },
+      });
+    }
+
+    return normalized;
+  }
+
+  private normalizeProvider(provider: string): AiProvider {
+    if (!AI_PROVIDER_VALUES.includes(provider as AiProvider)) {
+      throw new BadRequestException({
+        error: {
+          code: 'INVALID_PROVIDER',
+          message: `Provider must be one of: ${AI_PROVIDER_VALUES.join(', ')}`,
+        },
+      });
+    }
+
+    return provider as AiProvider;
+  }
+
+  private throwModelNotAllowed(): never {
+    throw new BadRequestException({
+      error: {
+        code: 'MODEL_NOT_ALLOWED',
+        message: 'Model is not available for this account',
+      },
+    });
+  }
+
+  private toAdminModelView(
+    model: Pick<
+      AiModelConfig,
+      | 'id'
+      | 'isActive'
+      | 'label'
+      | 'pricing'
+      | 'provider'
+      | 'providerModel'
+      | 'updatedAt'
+    >,
+  ): AdminModelView {
+    return {
+      id: model.id,
+      isActive: model.isActive,
+      label: model.label,
+      pricing: {
+        completionUsdPer1M: model.pricing.completionUsdPer1M,
+        promptUsdPer1M: model.pricing.promptUsdPer1M,
+      },
+      provider: model.provider,
+      providerModel: model.providerModel,
+      updatedAt: model.updatedAt,
+    };
+  }
+}

--- a/packages/mukti-api/src/modules/ai/services/ai-cost.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/ai-cost.service.ts
@@ -1,0 +1,13 @@
+import type { AiModelPricing } from '../../../schemas/ai-model-config.schema';
+
+export function calculateAiCostUsd(params: {
+  completionTokens: number;
+  pricing: AiModelPricing;
+  promptTokens: number;
+}): number {
+  const promptCost = params.promptTokens * params.pricing.promptUsdPer1M;
+  const completionCost =
+    params.completionTokens * params.pricing.completionUsdPer1M;
+
+  return (promptCost + completionCost) / 1_000_000;
+}

--- a/packages/mukti-api/src/modules/ai/services/ai-gateway.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/ai-gateway.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+
+import type { AiProvider } from '../../../schemas/ai-provider-config.schema';
+
+import { calculateAiCostUsd } from './ai-cost.service';
+import { AiConfigService } from './ai-config.service';
+import { AnthropicProviderService } from './providers/anthropic-provider.service';
+import { GeminiProviderService } from './providers/gemini-provider.service';
+import { OpenAiProviderService } from './providers/openai-provider.service';
+import { OpenRouterProviderService } from './providers/openrouter-provider.service';
+import type {
+  AiChatMessage,
+  AiProviderCompletionResult,
+} from './providers/provider.types';
+
+export interface AiGatewayResponse {
+  completionTokens: number;
+  content: string;
+  costUsd: number;
+  latencyMs: number;
+  model: string;
+  promptTokens: number;
+  provider: AiProvider;
+  totalTokens: number;
+}
+
+@Injectable()
+export class AiGatewayService {
+  constructor(
+    private readonly aiConfigService: AiConfigService,
+    private readonly openAiProviderService: OpenAiProviderService,
+    private readonly anthropicProviderService: AnthropicProviderService,
+    private readonly geminiProviderService: GeminiProviderService,
+    private readonly openRouterProviderService: OpenRouterProviderService,
+  ) {}
+
+  async createChatCompletion(params: {
+    messages: AiChatMessage[];
+    modelId: string;
+  }): Promise<AiGatewayResponse> {
+    const modelConfig = await this.aiConfigService.getModelForGeneration(
+      params.modelId,
+    );
+
+    const start = Date.now();
+
+    const providerResponse = await this.callProvider({
+      apiKey: modelConfig.apiKey,
+      messages: params.messages,
+      model: modelConfig.providerModel,
+      provider: modelConfig.provider,
+    });
+
+    const costUsd = calculateAiCostUsd({
+      completionTokens: providerResponse.completionTokens,
+      pricing: modelConfig.pricing,
+      promptTokens: providerResponse.promptTokens,
+    });
+
+    return {
+      completionTokens: providerResponse.completionTokens,
+      content: providerResponse.content,
+      costUsd,
+      latencyMs: Date.now() - start,
+      model: modelConfig.id,
+      promptTokens: providerResponse.promptTokens,
+      provider: modelConfig.provider,
+      totalTokens:
+        providerResponse.totalTokens ||
+        providerResponse.promptTokens + providerResponse.completionTokens,
+    };
+  }
+
+  private async callProvider(params: {
+    apiKey: string;
+    messages: AiChatMessage[];
+    model: string;
+    provider: AiProvider;
+  }): Promise<AiProviderCompletionResult> {
+    if (params.provider === 'openai') {
+      return this.openAiProviderService.createChatCompletion({
+        apiKey: params.apiKey,
+        messages: params.messages,
+        model: params.model,
+      });
+    }
+
+    if (params.provider === 'anthropic') {
+      return this.anthropicProviderService.createChatCompletion({
+        apiKey: params.apiKey,
+        messages: params.messages,
+        model: params.model,
+      });
+    }
+
+    if (params.provider === 'gemini') {
+      return this.geminiProviderService.createChatCompletion({
+        apiKey: params.apiKey,
+        messages: params.messages,
+        model: params.model,
+      });
+    }
+
+    return this.openRouterProviderService.createChatCompletion({
+      apiKey: params.apiKey,
+      messages: params.messages,
+      model: params.model,
+    });
+  }
+}

--- a/packages/mukti-api/src/modules/ai/services/providers/anthropic-provider.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/providers/anthropic-provider.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+
+import type {
+  AiChatMessage,
+  AiProviderCompletionResult,
+} from './provider.types';
+
+interface AnthropicResponsePayload {
+  content?: Array<{
+    text?: string;
+    type?: string;
+  }>;
+  error?: {
+    message?: string;
+  };
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+@Injectable()
+export class AnthropicProviderService {
+  async createChatCompletion(params: {
+    apiKey: string;
+    messages: AiChatMessage[];
+    model: string;
+  }): Promise<AiProviderCompletionResult> {
+    const systemMessage = params.messages
+      .filter((message) => message.role === 'system')
+      .map((message) => message.content)
+      .join('\n\n')
+      .trim();
+
+    const dialogueMessages = params.messages
+      .filter((message) => message.role !== 'system')
+      .map((message) => ({
+        content: message.content,
+        role: message.role,
+      }));
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      body: JSON.stringify({
+        max_tokens: 1024,
+        messages: dialogueMessages,
+        model: params.model,
+        ...(systemMessage ? { system: systemMessage } : {}),
+        temperature: 0.7,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        'x-api-key': params.apiKey,
+      },
+      method: 'POST',
+    });
+
+    const payload = (await response.json()) as AnthropicResponsePayload;
+
+    if (!response.ok) {
+      const message =
+        payload.error?.message ??
+        `Anthropic request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    const promptTokens = payload.usage?.input_tokens ?? 0;
+    const completionTokens = payload.usage?.output_tokens ?? 0;
+
+    return {
+      completionTokens,
+      content: this.extractContent(payload.content),
+      promptTokens,
+      totalTokens: promptTokens + completionTokens,
+    };
+  }
+
+  private extractContent(
+    content:
+      | Array<{
+          text?: string;
+          type?: string;
+        }>
+      | undefined,
+  ): string {
+    if (!content?.length) {
+      return '';
+    }
+
+    return content
+      .map((part) => {
+        if (part.type === 'text' && typeof part.text === 'string') {
+          return part.text;
+        }
+
+        return '';
+      })
+      .filter((part) => part.length > 0)
+      .join(' ');
+  }
+}

--- a/packages/mukti-api/src/modules/ai/services/providers/gemini-provider.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/providers/gemini-provider.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+
+import type {
+  AiChatMessage,
+  AiProviderCompletionResult,
+} from './provider.types';
+
+interface GeminiResponsePayload {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+      }>;
+    };
+  }>;
+  error?: {
+    message?: string;
+  };
+  usageMetadata?: {
+    candidatesTokenCount?: number;
+    promptTokenCount?: number;
+    totalTokenCount?: number;
+  };
+}
+
+@Injectable()
+export class GeminiProviderService {
+  async createChatCompletion(params: {
+    apiKey: string;
+    messages: AiChatMessage[];
+    model: string;
+  }): Promise<AiProviderCompletionResult> {
+    const systemInstruction = params.messages
+      .filter((message) => message.role === 'system')
+      .map((message) => message.content)
+      .join('\n\n')
+      .trim();
+
+    const contents = params.messages
+      .filter((message) => message.role !== 'system')
+      .map((message) => ({
+        parts: [{ text: message.content }],
+        role: message.role === 'assistant' ? 'model' : 'user',
+      }));
+
+    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(params.model)}:generateContent?key=${encodeURIComponent(params.apiKey)}`;
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        ...(systemInstruction
+          ? {
+              system_instruction: {
+                parts: [{ text: systemInstruction }],
+              },
+            }
+          : {}),
+        contents,
+        generationConfig: {
+          temperature: 0.7,
+        },
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    const payload = (await response.json()) as GeminiResponsePayload;
+
+    if (!response.ok) {
+      const message =
+        payload.error?.message ??
+        `Gemini request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    const promptTokens = payload.usageMetadata?.promptTokenCount ?? 0;
+    const completionTokens = payload.usageMetadata?.candidatesTokenCount ?? 0;
+    const totalTokens =
+      payload.usageMetadata?.totalTokenCount ?? promptTokens + completionTokens;
+
+    const content =
+      payload.candidates?.[0]?.content?.parts
+        ?.map((part) => part.text ?? '')
+        .filter((part) => part.length > 0)
+        .join(' ') ?? '';
+
+    return {
+      completionTokens,
+      content,
+      promptTokens,
+      totalTokens,
+    };
+  }
+}

--- a/packages/mukti-api/src/modules/ai/services/providers/openai-provider.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/providers/openai-provider.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+
+import type {
+  AiChatMessage,
+  AiProviderCompletionResult,
+} from './provider.types';
+
+interface OpenAiResponsePayload {
+  choices?: Array<{
+    message?: {
+      content?:
+        | Array<{
+            text?: string;
+            type?: string;
+          }>
+        | null
+        | string;
+    };
+  }>;
+  error?: {
+    message?: string;
+  };
+  usage?: {
+    completion_tokens?: number;
+    prompt_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+@Injectable()
+export class OpenAiProviderService {
+  async createChatCompletion(params: {
+    apiKey: string;
+    messages: AiChatMessage[];
+    model: string;
+  }): Promise<AiProviderCompletionResult> {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      body: JSON.stringify({
+        messages: params.messages,
+        model: params.model,
+        temperature: 0.7,
+      }),
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    const payload = (await response.json()) as OpenAiResponsePayload;
+
+    if (!response.ok) {
+      const message =
+        payload.error?.message ??
+        `OpenAI request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    const promptTokens = payload.usage?.prompt_tokens ?? 0;
+    const completionTokens = payload.usage?.completion_tokens ?? 0;
+    const totalTokens =
+      payload.usage?.total_tokens ?? promptTokens + completionTokens;
+
+    return {
+      completionTokens,
+      content: this.extractContent(payload.choices?.[0]?.message?.content),
+      promptTokens,
+      totalTokens,
+    };
+  }
+
+  private extractContent(
+    content:
+      | Array<{
+          text?: string;
+          type?: string;
+        }>
+      | null
+      | string
+      | undefined,
+  ): string {
+    if (typeof content === 'string') {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (part.type === 'text' && typeof part.text === 'string') {
+            return part.text;
+          }
+
+          return '';
+        })
+        .filter((part) => part.length > 0)
+        .join(' ');
+    }
+
+    return '';
+  }
+}

--- a/packages/mukti-api/src/modules/ai/services/providers/openrouter-provider.service.ts
+++ b/packages/mukti-api/src/modules/ai/services/providers/openrouter-provider.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { OpenRouterClientFactory } from '../openrouter-client.factory';
+
+import type {
+  AiChatMessage,
+  AiProviderCompletionResult,
+} from './provider.types';
+
+interface OpenRouterChatChoice {
+  message?: {
+    content?: OpenRouterContentPart[] | null | string;
+  };
+}
+
+interface OpenRouterContentPart {
+  text?: string;
+  type?: string;
+}
+
+interface OpenRouterResponsePayload {
+  choices?: OpenRouterChatChoice[];
+  usage?: {
+    completion_tokens?: number;
+    completionTokens?: number;
+    prompt_tokens?: number;
+    promptTokens?: number;
+    total_tokens?: number;
+    totalTokens?: number;
+  };
+}
+
+@Injectable()
+export class OpenRouterProviderService {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly openRouterClientFactory: OpenRouterClientFactory,
+  ) {}
+
+  async createChatCompletion(params: {
+    apiKey: string;
+    messages: AiChatMessage[];
+    model: string;
+  }): Promise<AiProviderCompletionResult> {
+    const client = this.openRouterClientFactory.create(params.apiKey);
+
+    const response = await client.chat.send(
+      {
+        messages: params.messages,
+        model: params.model,
+        stream: false,
+        temperature: 0.7,
+      },
+      {
+        headers: {
+          'HTTP-Referer':
+            this.configService.get<string>('APP_URL') ?? 'https://mukti.app',
+          'X-Title': 'Mukti - Thinking Workspace',
+        },
+      },
+    );
+
+    const safeResponse = this.isResponsePayload(response)
+      ? response
+      : { choices: [], usage: undefined };
+
+    const usage = safeResponse.usage;
+    const promptTokens = usage?.promptTokens ?? usage?.prompt_tokens ?? 0;
+    const completionTokens =
+      usage?.completionTokens ?? usage?.completion_tokens ?? 0;
+    const totalTokens =
+      usage?.totalTokens ??
+      usage?.total_tokens ??
+      promptTokens + completionTokens;
+
+    return {
+      completionTokens,
+      content: this.extractContent(safeResponse.choices?.[0]),
+      promptTokens,
+      totalTokens,
+    };
+  }
+
+  private extractContent(choice?: OpenRouterChatChoice): string {
+    const content = choice?.message?.content;
+
+    if (typeof content === 'string') {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === 'string') {
+            return part;
+          }
+
+          if (part.type === 'text' && typeof part.text === 'string') {
+            return part.text;
+          }
+
+          return '';
+        })
+        .filter((part) => part.length > 0)
+        .join(' ');
+    }
+
+    return '';
+  }
+
+  private isResponsePayload(
+    payload: unknown,
+  ): payload is OpenRouterResponsePayload {
+    return typeof payload === 'object' && payload !== null;
+  }
+}

--- a/packages/mukti-api/src/modules/ai/services/providers/provider.types.ts
+++ b/packages/mukti-api/src/modules/ai/services/providers/provider.types.ts
@@ -1,0 +1,11 @@
+export interface AiChatMessage {
+  content: string;
+  role: 'assistant' | 'system' | 'user';
+}
+
+export interface AiProviderCompletionResult {
+  completionTokens: number;
+  content: string;
+  promptTokens: number;
+  totalTokens: number;
+}

--- a/packages/mukti-api/src/modules/conversations/__tests__/conversation.controller.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/__tests__/conversation.controller.spec.ts
@@ -1,11 +1,9 @@
-import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { Types } from 'mongoose';
 
 import { User } from '../../../schemas/user.schema';
-import { AiPolicyService } from '../../ai/services/ai-policy.service';
-import { AiSecretsService } from '../../ai/services/ai-secrets.service';
+import { AiConfigService } from '../../ai/services/ai-config.service';
 import { ConversationController } from '../conversation.controller';
 import { ConversationService } from '../services/conversation.service';
 import { MessageService } from '../services/message.service';
@@ -67,16 +65,12 @@ describe('ConversationController', () => {
     removeConnection: jest.fn(),
   };
 
-  const mockConfigService = {
-    get: jest.fn().mockReturnValue('mock-api-key'),
-  };
-
-  const mockAiPolicyService = {
-    resolveEffectiveModel: jest.fn().mockResolvedValue(undefined),
-  };
-
-  const mockAiSecretsService = {
-    decryptString: jest.fn(),
+  const mockAiConfigService = {
+    resolveModelSelection: jest.fn().mockResolvedValue({
+      activeModel: 'test-model',
+      aiConfigured: true,
+      shouldPersist: false,
+    }),
   };
 
   const mockUserModel = {
@@ -99,16 +93,8 @@ describe('ConversationController', () => {
           useValue: mockUserModel,
         },
         {
-          provide: ConfigService,
-          useValue: mockConfigService,
-        },
-        {
-          provide: AiPolicyService,
-          useValue: mockAiPolicyService,
-        },
-        {
-          provide: AiSecretsService,
-          useValue: mockAiSecretsService,
+          provide: AiConfigService,
+          useValue: mockAiConfigService,
         },
         {
           provide: ConversationService,
@@ -554,8 +540,7 @@ describe('ConversationController', () => {
         sendMessageDto.content,
         'free',
         'elenchus',
-        undefined,
-        false,
+        'test-model',
       );
     });
   });

--- a/packages/mukti-api/src/modules/conversations/__tests__/properties/connection-ownership.property.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/__tests__/properties/connection-ownership.property.spec.ts
@@ -1,5 +1,4 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, type TestingModule } from '@nestjs/testing';
 import * as fc from 'fast-check';
@@ -11,8 +10,7 @@ jest.mock('@openrouter/sdk', () => ({
 }));
 
 import { User } from '../../../../schemas/user.schema';
-import { AiPolicyService } from '../../../ai/services/ai-policy.service';
-import { AiSecretsService } from '../../../ai/services/ai-secrets.service';
+import { AiConfigService } from '../../../ai/services/ai-config.service';
 import { ConversationController } from '../../conversation.controller';
 import { ConversationService } from '../../services/conversation.service';
 import { MessageService } from '../../services/message.service';
@@ -76,21 +74,9 @@ describe('ConversationController - SSE Authentication (Property-Based)', () => {
           },
         },
         {
-          provide: ConfigService,
+          provide: AiConfigService,
           useValue: {
-            get: jest.fn(),
-          },
-        },
-        {
-          provide: AiPolicyService,
-          useValue: {
-            resolveEffectiveModel: jest.fn(),
-          },
-        },
-        {
-          provide: AiSecretsService,
-          useValue: {
-            decryptString: jest.fn(),
+            resolveModelSelection: jest.fn(),
           },
         },
       ],

--- a/packages/mukti-api/src/modules/conversations/__tests__/properties/connection-token-validation.property.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/__tests__/properties/connection-token-validation.property.spec.ts
@@ -1,5 +1,4 @@
 import { type ExecutionContext, UnauthorizedException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -12,8 +11,7 @@ jest.mock('@openrouter/sdk', () => ({
 }));
 
 import { User } from '../../../../schemas/user.schema';
-import { AiPolicyService } from '../../../ai/services/ai-policy.service';
-import { AiSecretsService } from '../../../ai/services/ai-secrets.service';
+import { AiConfigService } from '../../../ai/services/ai-config.service';
 import { JwtAuthGuard } from '../../../auth/guards/jwt-auth.guard';
 import { ConversationController } from '../../conversation.controller';
 import { ConversationService } from '../../services/conversation.service';
@@ -80,21 +78,9 @@ describe('ConversationController - SSE Authentication Validation (Property-Based
           },
         },
         {
-          provide: ConfigService,
+          provide: AiConfigService,
           useValue: {
-            get: jest.fn(),
-          },
-        },
-        {
-          provide: AiPolicyService,
-          useValue: {
-            resolveEffectiveModel: jest.fn(),
-          },
-        },
-        {
-          provide: AiSecretsService,
-          useValue: {
-            decryptString: jest.fn(),
+            resolveModelSelection: jest.fn(),
           },
         },
         Reflector,

--- a/packages/mukti-api/src/modules/conversations/conversations.module.ts
+++ b/packages/mukti-api/src/modules/conversations/conversations.module.ts
@@ -22,7 +22,6 @@ import { AiModule } from '../ai/ai.module';
 import { ConversationController } from './conversation.controller';
 import { ConversationService } from './services/conversation.service';
 import { MessageService } from './services/message.service';
-import { OpenRouterService } from './services/openrouter.service';
 import { QueueService } from './services/queue.service';
 import { SeedService } from './services/seed.service';
 import { StreamService } from './services/stream.service';
@@ -46,7 +45,6 @@ import { StreamService } from './services/stream.service';
     SeedService,
     ConversationService,
     MessageService,
-    OpenRouterService,
     QueueService,
     StreamService,
   ],
@@ -98,7 +96,6 @@ import { StreamService } from './services/stream.service';
     SeedService,
     ConversationService,
     MessageService,
-    OpenRouterService,
     QueueService,
     StreamService,
   ],

--- a/packages/mukti-api/src/modules/conversations/dto/send-message.dto.ts
+++ b/packages/mukti-api/src/modules/conversations/dto/send-message.dto.ts
@@ -20,7 +20,7 @@ export class SendMessageDto {
   content: string;
 
   @ApiPropertyOptional({
-    description: 'OpenRouter model id to use for this message',
+    description: 'AI model id to use for this message',
     example: 'openai/gpt-5-mini',
   })
   @IsOptional()

--- a/packages/mukti-api/src/modules/conversations/services/__tests__/openrouter.service.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/services/__tests__/openrouter.service.spec.ts
@@ -167,6 +167,7 @@ describe('OpenRouterService', () => {
             expect(result).toHaveProperty('completionTokens');
             expect(result).toHaveProperty('totalTokens');
             expect(result).toHaveProperty('cost');
+            expect(result).toHaveProperty('costUsd');
             expect(result).toHaveProperty('model');
 
             // Property: Content should match response
@@ -185,6 +186,7 @@ describe('OpenRouterService', () => {
             // Property: Cost is currently treated as unknown
             expect(typeof result.cost).toBe('number');
             expect(result.cost).toBe(0);
+            expect(result.costUsd).toBe(0);
           },
         ),
         { numRuns: 100 },
@@ -203,6 +205,7 @@ describe('OpenRouterService', () => {
       expect(result.completionTokens).toBe(0);
       expect(result.totalTokens).toBe(0);
       expect(result.cost).toBe(0);
+      expect(result.costUsd).toBe(0);
     });
 
     it('should handle empty content', () => {
@@ -219,6 +222,27 @@ describe('OpenRouterService', () => {
 
       expect(result.content).toBe('');
       expect(result.promptTokens).toBe(10);
+    });
+
+    it('should compute cost from pricing and token usage', () => {
+      const response: any = {
+        choices: [{ message: { content: 'Test response' } }],
+        usage: {
+          completion_tokens: 1000,
+          prompt_tokens: 2000,
+        },
+      };
+
+      const result = service.parseResponse(response, 'openai/gpt-5-mini', {
+        completionUsdPer1M: 0.8,
+        promptUsdPer1M: 0.2,
+      });
+
+      expect(result.promptTokens).toBe(2000);
+      expect(result.completionTokens).toBe(1000);
+      expect(result.totalTokens).toBe(3000);
+      expect(result.costUsd).toBeCloseTo(0.0012, 8);
+      expect(result.cost).toBeCloseTo(0.0012, 8);
     });
   });
 

--- a/packages/mukti-api/src/modules/dialogue/dialogue.service.ts
+++ b/packages/mukti-api/src/modules/dialogue/dialogue.service.ts
@@ -86,9 +86,14 @@ export class DialogueService {
     role: MessageRole,
     content: string,
     metadata?: {
+      completionTokens?: number;
+      costUsd?: number;
       latencyMs?: number;
       model?: string;
+      promptTokens?: number;
+      provider?: string;
       tokens?: number;
+      totalTokens?: number;
     },
   ): Promise<DialogueMessage> {
     const dialogueObjectId =

--- a/packages/mukti-api/src/modules/dialogue/dto/send-message.dto.ts
+++ b/packages/mukti-api/src/modules/dialogue/dto/send-message.dto.ts
@@ -24,7 +24,7 @@ export class DialogueSendMessageDto {
   content: string;
 
   @ApiPropertyOptional({
-    description: 'OpenRouter model id to use for this message',
+    description: 'AI model id to use for this message',
     example: 'openai/gpt-5-mini',
   })
   @IsOptional()

--- a/packages/mukti-api/src/schemas/ai-model-config.schema.ts
+++ b/packages/mukti-api/src/schemas/ai-model-config.schema.ts
@@ -1,0 +1,61 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+import {
+  AI_PROVIDER_VALUES,
+  type AiProvider,
+} from './ai-provider-config.schema';
+
+export type AiModelConfigDocument = Document & AiModelConfig;
+
+export interface AiModelPricing {
+  completionUsdPer1M: number;
+  promptUsdPer1M: number;
+}
+
+@Schema({ _id: false, id: false })
+export class AiModelPricingConfig implements AiModelPricing {
+  @Prop({ default: 0, min: 0, required: true, type: Number })
+  completionUsdPer1M: number;
+
+  @Prop({ default: 0, min: 0, required: true, type: Number })
+  promptUsdPer1M: number;
+}
+
+const AiModelPricingConfigSchema =
+  SchemaFactory.createForClass(AiModelPricingConfig);
+
+@Schema({
+  collection: 'ai_model_configs',
+  timestamps: true,
+})
+export class AiModelConfig {
+  _id: string;
+
+  createdAt: Date;
+
+  @Prop({ required: true, trim: true, type: String, unique: true })
+  id: string;
+
+  @Prop({ default: true, type: Boolean })
+  isActive: boolean;
+
+  @Prop({ required: true, trim: true, type: String })
+  label: string;
+
+  @Prop({ enum: AI_PROVIDER_VALUES, required: true, type: String })
+  provider: AiProvider;
+
+  @Prop({ required: true, trim: true, type: String })
+  providerModel: string;
+
+  @Prop({ required: true, type: AiModelPricingConfigSchema })
+  pricing: AiModelPricingConfig;
+
+  updatedAt: Date;
+}
+
+export const AiModelConfigSchema = SchemaFactory.createForClass(AiModelConfig);
+
+AiModelConfigSchema.index({ id: 1 }, { unique: true });
+AiModelConfigSchema.index({ isActive: 1, provider: 1 });

--- a/packages/mukti-api/src/schemas/ai-provider-config.schema.ts
+++ b/packages/mukti-api/src/schemas/ai-provider-config.schema.ts
@@ -1,0 +1,38 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export const AI_PROVIDER_VALUES = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'openrouter',
+] as const;
+
+export type AiProvider = (typeof AI_PROVIDER_VALUES)[number];
+
+export type AiProviderConfigDocument = Document & AiProviderConfig;
+
+@Schema({
+  collection: 'ai_provider_configs',
+  timestamps: { createdAt: false, updatedAt: true },
+})
+export class AiProviderConfig {
+  @Prop({ enum: AI_PROVIDER_VALUES, index: true, required: true, unique: true })
+  provider: AiProvider;
+
+  @Prop({ required: false, select: false, type: String })
+  apiKeyEncrypted?: string;
+
+  @Prop({ required: false, type: String })
+  apiKeyLast4?: string;
+
+  @Prop({ default: false, type: Boolean })
+  isActive: boolean;
+
+  updatedAt: Date;
+}
+
+export const AiProviderConfigSchema =
+  SchemaFactory.createForClass(AiProviderConfig);
+
+AiProviderConfigSchema.index({ provider: 1 }, { unique: true });

--- a/packages/mukti-api/src/schemas/dialogue-message.schema.ts
+++ b/packages/mukti-api/src/schemas/dialogue-message.schema.ts
@@ -7,12 +7,22 @@ export type DialogueMessageDocument = DialogueMessage & Document;
  * Metadata for AI-generated messages.
  */
 export interface DialogueMessageMetadata {
+  /** Completion token count for the model response */
+  completionTokens?: number;
+  /** Estimated cost in USD for the model response */
+  costUsd?: number;
   /** Time taken to generate the response in milliseconds */
   latencyMs?: number;
   /** AI model used for generation */
   model?: string;
+  /** Token count for the prompt */
+  promptTokens?: number;
+  /** Provider used to generate this response */
+  provider?: string;
   /** Token count for the message */
   tokens?: number;
+  /** Total token count for prompt + completion */
+  totalTokens?: number;
 }
 
 /**

--- a/packages/mukti-api/src/schemas/usage-event.schema.ts
+++ b/packages/mukti-api/src/schemas/usage-event.schema.ts
@@ -8,12 +8,15 @@ export interface UsageEventMetadata {
   completionTokens?: number;
   conversationId?: Types.ObjectId;
   cost?: number;
+  costUsd?: number;
   error?: string;
   latencyMs?: number;
   model?: string;
   promptTokens?: number;
+  provider?: string;
   statusCode?: number;
   technique?: string;
+  totalTokens?: number;
   tokens?: number;
 }
 

--- a/packages/mukti-web/src/app/dashboard/settings/page.tsx
+++ b/packages/mukti-web/src/app/dashboard/settings/page.tsx
@@ -1,39 +1,16 @@
 'use client';
 
-import { AlertCircle, CheckCircle2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { ModelSelector } from '@/components/ai/model-selector';
 import { DashboardLayout } from '@/components/layouts/dashboard-layout';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { useAiStore } from '@/lib/stores/ai-store';
 
 export default function SettingsPage() {
-  const {
-    activeModel,
-    deleteGeminiKey,
-    deleteOpenRouterKey,
-    geminiKeyLast4,
-    hasGeminiKey,
-    hasOpenRouterKey,
-    hydrate,
-    isHydrated,
-    models,
-    openRouterKeyLast4,
-    refreshModels,
-    setActiveModel,
-    setGeminiKey,
-    setOpenRouterKey,
-  } = useAiStore();
+  const { activeModel, aiConfigured, hydrate, isHydrated, models, refreshModels, setActiveModel } =
+    useAiStore();
 
-  const [apiKey, setApiKey] = useState('');
-  const [geminiKey, setGeminiKeyInput] = useState('');
-  const [savingKey, setSavingKey] = useState(false);
-  const [savingGeminiKey, setSavingGeminiKey] = useState(false);
-  const [removingKey, setRemovingKey] = useState(false);
-  const [removingGeminiKey, setRemovingGeminiKey] = useState(false);
   const [savingModel, setSavingModel] = useState(false);
 
   useEffect(() => {
@@ -48,14 +25,14 @@ export default function SettingsPage() {
         <section className="space-y-3 rounded-lg border p-4">
           <h2 className="text-lg font-semibold">AI</h2>
           <p className="text-sm text-muted-foreground">
-            Pick your active model and optionally connect your own OpenRouter key.
+            AI providers and API keys are configured on the server by your workspace admin.
           </p>
 
           <div className="space-y-2">
             <label className="text-sm font-medium">Active model</label>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <ModelSelector
-                className="flex-1 h-11"
+                className="h-11 flex-1"
                 models={models}
                 onChange={async (modelId) => {
                   setSavingModel(true);
@@ -69,7 +46,7 @@ export default function SettingsPage() {
                 value={activeModel}
               />
               <Button
-                className="h-11 px-4 shrink-0"
+                className="h-11 shrink-0 px-4"
                 onClick={() => refreshModels()}
                 type="button"
                 variant="outline"
@@ -77,167 +54,13 @@ export default function SettingsPage() {
                 Refresh models
               </Button>
             </div>
+            {!aiConfigured && (
+              <p className="text-xs text-muted-foreground">
+                AI is currently unavailable. Ask your admin to configure an active provider and
+                model.
+              </p>
+            )}
             {savingModel && <p className="text-xs text-muted-foreground">Saving model…</p>}
-          </div>
-        </section>
-
-        <section className="space-y-3 rounded-lg border p-4">
-          <h3 className="text-lg font-semibold">OpenRouter API key</h3>
-          <p className="text-sm text-muted-foreground">
-            If you add a key, Mukti will use it for all AI calls.
-          </p>
-
-          <div className="space-y-2">
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Input
-                aria-label="OpenRouter API key"
-                className="h-11 flex-1"
-                disabled={hasOpenRouterKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={
-                  hasOpenRouterKey ? 'Remove existing key to add a new one' : 'sk-or-v1-…'
-                }
-                type="password"
-                value={apiKey}
-              />
-              <Button
-                className="h-11 px-4 shrink-0"
-                disabled={savingKey || apiKey.trim().length === 0 || hasOpenRouterKey}
-                onClick={async () => {
-                  setSavingKey(true);
-                  try {
-                    await setOpenRouterKey(apiKey);
-                    setApiKey('');
-                  } finally {
-                    setSavingKey(false);
-                  }
-                }}
-                type="button"
-              >
-                Save key
-              </Button>
-            </div>
-
-            <div className="flex items-center justify-between gap-3 min-h-[44px]">
-              <div>
-                {hasOpenRouterKey ? (
-                  <Badge
-                    className="gap-1.5 border-green-500/50 bg-green-500/10 py-1.5 px-3 text-sm text-green-500 h-9"
-                    variant="outline"
-                  >
-                    <CheckCircle2 className="h-4 w-4" />
-                    Connected (…{openRouterKeyLast4 ?? '????'})
-                  </Badge>
-                ) : (
-                  <Badge
-                    className="gap-1.5 py-1.5 px-3 text-sm text-muted-foreground h-9"
-                    variant="secondary"
-                  >
-                    <AlertCircle className="h-4 w-4" />
-                    Not connected
-                  </Badge>
-                )}
-              </div>
-              {hasOpenRouterKey && (
-                <Button
-                  className="h-9 px-4 hover:bg-red-900/20 hover:text-red-400"
-                  disabled={removingKey}
-                  onClick={async () => {
-                    setRemovingKey(true);
-                    try {
-                      await deleteOpenRouterKey();
-                    } finally {
-                      setRemovingKey(false);
-                    }
-                  }}
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  <span className="text-red-400">Remove key</span>
-                </Button>
-              )}
-            </div>
-
-            {savingKey && <p className="text-xs text-muted-foreground">Saving key…</p>}
-          </div>
-        </section>
-
-        <section className="space-y-3 rounded-lg border p-4">
-          <h3 className="text-lg font-semibold">Gemini API key</h3>
-          <p className="text-sm text-muted-foreground">Connect your Google Gemini API key.</p>
-
-          <div className="space-y-2">
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Input
-                aria-label="Gemini API key"
-                className="h-11 flex-1"
-                disabled={hasGeminiKey}
-                onChange={(e) => setGeminiKeyInput(e.target.value)}
-                placeholder={hasGeminiKey ? 'Remove existing key to add a new one' : 'AIzaSy…'}
-                type="password"
-                value={geminiKey}
-              />
-              <Button
-                className="h-11 px-4 shrink-0"
-                disabled={savingGeminiKey || geminiKey.trim().length === 0 || hasGeminiKey}
-                onClick={async () => {
-                  setSavingGeminiKey(true);
-                  try {
-                    await setGeminiKey(geminiKey);
-                    setGeminiKeyInput('');
-                  } finally {
-                    setSavingGeminiKey(false);
-                  }
-                }}
-                type="button"
-              >
-                Save key
-              </Button>
-            </div>
-
-            <div className="flex items-center justify-between gap-3 min-h-[44px]">
-              <div>
-                {hasGeminiKey ? (
-                  <Badge
-                    className="gap-1.5 border-green-500/50 bg-green-500/10 py-1.5 px-3 text-sm text-green-500 h-9"
-                    variant="outline"
-                  >
-                    <CheckCircle2 className="h-4 w-4" />
-                    Connected (…{geminiKeyLast4 ?? '????'})
-                  </Badge>
-                ) : (
-                  <Badge
-                    className="gap-1.5 py-1.5 px-3 text-sm text-muted-foreground h-9"
-                    variant="secondary"
-                  >
-                    <AlertCircle className="h-4 w-4" />
-                    Not connected
-                  </Badge>
-                )}
-              </div>
-              {hasGeminiKey && (
-                <Button
-                  className="h-9 px-4 hover:bg-red-900/20 hover:text-red-400"
-                  disabled={removingGeminiKey}
-                  onClick={async () => {
-                    setRemovingGeminiKey(true);
-                    try {
-                      await deleteGeminiKey();
-                    } finally {
-                      setRemovingGeminiKey(false);
-                    }
-                  }}
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  <span className="text-red-400">Remove key</span>
-                </Button>
-              )}
-            </div>
-
-            {savingGeminiKey && <p className="text-xs text-muted-foreground">Saving key…</p>}
           </div>
         </section>
       </div>

--- a/packages/mukti-web/src/components/ai/model-selector.tsx
+++ b/packages/mukti-web/src/components/ai/model-selector.tsx
@@ -80,7 +80,7 @@ export function ModelSelector({
           <DialogHeader>
             <DialogTitle>Select Model</DialogTitle>
             <DialogDescription>
-              Choose which OpenRouter model to use for your next message.
+              Choose which configured AI model to use for your next message.
             </DialogDescription>
           </DialogHeader>
 

--- a/packages/mukti-web/src/lib/api/ai.ts
+++ b/packages/mukti-web/src/lib/api/ai.ts
@@ -1,77 +1,25 @@
 import { apiClient } from './client';
 
-export type AiSettings = {
-  activeModel?: string;
-  geminiKeyLast4: null | string;
-  hasGeminiKey: boolean;
-  hasOpenRouterKey: boolean;
-  openRouterKeyLast4: null | string;
+export type AiModel = {
+  id: string;
+  label: string;
 };
 
-type AiModelsResponse =
-  | { mode: 'curated'; models: CuratedModel[] }
-  | { mode: 'openrouter'; models: OpenRouterModel[] };
-
-type CuratedModel = { id: string; label: string };
-
-type OpenRouterModel = { id: string; name: string };
+export type AiSettings = {
+  activeModel?: null | string;
+  aiConfigured: boolean;
+};
 
 export const aiApi = {
-  deleteGeminiKey: async (): Promise<{
-    geminiKeyLast4: null;
-    hasGeminiKey: boolean;
-  }> => {
-    return apiClient.delete<{ geminiKeyLast4: null; hasGeminiKey: boolean }>('/ai/gemini-key');
-  },
-
-  deleteOpenRouterKey: async (): Promise<{
-    hasOpenRouterKey: boolean;
-    openRouterKeyLast4: null;
-  }> => {
-    return apiClient.delete<{ hasOpenRouterKey: boolean; openRouterKeyLast4: null }>(
-      '/ai/openrouter-key'
-    );
-  },
-
-  getModels: async (): Promise<AiModelsResponse> => {
-    const response = await apiClient.get<{ mode: 'curated' | 'openrouter'; models: any[] }>(
-      '/ai/models'
-    );
-
-    if (response.mode === 'curated') {
-      return { mode: 'curated', models: response.models as CuratedModel[] };
-    }
-
-    return { mode: 'openrouter', models: response.models as OpenRouterModel[] };
+  getModels: async (): Promise<{ models: AiModel[] }> => {
+    return apiClient.get<{ models: AiModel[] }>('/ai/models');
   },
 
   getSettings: async (): Promise<AiSettings> => {
-    const response = await apiClient.get<{
-      activeModel?: string;
-      geminiKeyLast4: null | string;
-      hasGeminiKey: boolean;
-      hasOpenRouterKey: boolean;
-      openRouterKeyLast4: null | string;
-    }>('/ai/settings');
-    return response;
+    return apiClient.get<AiSettings>('/ai/settings');
   },
 
-  setGeminiKey: async (dto: {
-    apiKey: string;
-  }): Promise<{ geminiKeyLast4: string; hasGeminiKey: boolean }> => {
-    return apiClient.put<{ geminiKeyLast4: string; hasGeminiKey: boolean }>('/ai/gemini-key', dto);
-  },
-
-  setOpenRouterKey: async (dto: {
-    apiKey: string;
-  }): Promise<{ hasOpenRouterKey: boolean; openRouterKeyLast4: string }> => {
-    return apiClient.put<{ hasOpenRouterKey: boolean; openRouterKeyLast4: string }>(
-      '/ai/openrouter-key',
-      dto
-    );
-  },
-
-  updateSettings: async (dto: { activeModel: string }): Promise<{ activeModel: string }> => {
-    return apiClient.patch<{ activeModel: string }>('/ai/settings', dto);
+  updateSettings: async (dto: { activeModel?: string }): Promise<AiSettings> => {
+    return apiClient.patch<AiSettings>('/ai/settings', dto);
   },
 };


### PR DESCRIPTION
## Summary
- remove end-user API key management from web settings and move AI key configuration fully to backend admin endpoints
- add backend AI provider/model configuration with RBAC-protected admin APIs for providers and models
- support provider routing through a unified AI gateway for OpenAI, Anthropic (Claude), Gemini, and OpenRouter based on active model/provider config
- enforce model eligibility using active model + active provider checks for `/ai/settings`, `/ai/models`, conversation send, and dialogue send flows
- add deterministic cost calculation from configured model pricing and propagate prompt/completion/total tokens + cost into usage metadata

## Backend changes
### AI config and admin management
- added `AiProviderConfig` schema for encrypted server-side provider keys, active status, and key last4
- added `AiModelConfig` schema for public model id, provider mapping, provider model id, active status, and pricing
- added admin-only endpoints under `/ai/admin` for:
  - listing providers/models
  - setting provider keys
  - toggling provider/model active status
  - upserting model config
  - deleting model config

### Consumer AI endpoints
- simplified `/ai/settings` response to user-facing fields only (`activeModel`, `aiConfigured`)
- simplified `/ai/models` response to active models from active providers
- removed BYOK `/ai/openrouter-key` and `/ai/gemini-key` flows

### AI routing and usage accounting
- introduced `AiGatewayService` with provider adapters:
  - OpenAI
  - Anthropic
  - Gemini
  - OpenRouter
- refactored conversation queue and dialogue queue to use gateway routing instead of per-user BYOK logic
- ensured usage metadata records provider/model/tokens/cost consistently
- added deterministic cost utility:
  - `costUsd = (promptTokens * promptUsdPer1M + completionTokens * completionUsdPer1M) / 1_000_000`

## Web changes
- removed OpenRouter and Gemini key UI sections from settings
- updated settings copy to indicate AI is configured on the server
- simplified web AI API/store to no longer call key management endpoints
- preserved active model selection + hydration behavior for conversation/canvas flows

## Tests
- added tests for:
  - model filtering by active provider/model
  - active model validation (`MODEL_NOT_ALLOWED` cases)
  - cost calculation correctness
- updated impacted controller/service tests for new backend-only config flow

## Notes
- no API keys are exposed to clients
- provider secrets continue to use `AiSecretsService` encryption at rest
- users with invalid/inactive stored model preferences are automatically normalized to a valid active model fallback
