### PR TITLE
Fix AI provider exclusivity, provider-aware models, and Gemini streaming

### DIFF
--- a/packages/mukti-api/src/modules/ai/__tests__/ai.controller.spec.ts
+++ b/packages/mukti-api/src/modules/ai/__tests__/ai.controller.spec.ts
@@ -1,0 +1,229 @@
+import { ConfigService } from '@nestjs/config';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+jest.mock('@openrouter/sdk', () => ({
+  OpenRouter: jest.fn(() => ({})),
+}));
+
+import { User } from '../../../schemas/user.schema';
+import { AiController } from '../ai.controller';
+import { AiPolicyService } from '../services/ai-policy.service';
+import { AiSecretsService } from '../services/ai-secrets.service';
+import { OpenRouterModelsService } from '../services/openrouter-models.service';
+
+type PlainObject = Record<string, any>;
+
+function applyUpdate(target: PlainObject, update: PlainObject) {
+  const set = update.$set ?? {};
+  const unset = update.$unset ?? {};
+
+  Object.entries(set).forEach(([path, value]) => {
+    setNested(target, path, value);
+  });
+
+  Object.keys(unset).forEach((path) => {
+    unsetNested(target, path);
+  });
+}
+
+function setNested(target: PlainObject, path: string, value: unknown) {
+  const keys = path.split('.');
+  let cursor = target;
+
+  for (let index = 0; index < keys.length - 1; index += 1) {
+    const key = keys[index];
+    if (!cursor[key] || typeof cursor[key] !== 'object') {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+
+  cursor[keys[keys.length - 1]] = value;
+}
+
+function unsetNested(target: PlainObject, path: string) {
+  const keys = path.split('.');
+  let cursor = target;
+
+  for (let index = 0; index < keys.length - 1; index += 1) {
+    const key = keys[index];
+    if (!cursor[key] || typeof cursor[key] !== 'object') {
+      return;
+    }
+    cursor = cursor[key];
+  }
+
+  delete cursor[keys[keys.length - 1]];
+}
+
+describe('AiController', () => {
+  let controller: AiController;
+  let aiPolicyService: AiPolicyService;
+  let openRouterModelsService: jest.Mocked<OpenRouterModelsService>;
+  let state: PlainObject;
+
+  const mockUserModel = {
+    findById: jest.fn(),
+    updateOne: jest.fn(),
+  };
+
+  const mockAiSecretsService = {
+    decryptString: jest.fn((cipher: string) => cipher.replace(/^enc:/, '')),
+    encryptString: jest.fn((plain: string) => `enc:${plain}`),
+  };
+
+  const mockOpenRouterModelsService = {
+    listModels: jest.fn(),
+    validateModelExists: jest.fn().mockResolvedValue(true),
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      if (key === 'OPENROUTER_API_KEY') {
+        return 'server-openrouter-key';
+      }
+
+      return undefined;
+    }),
+  };
+
+  const makeFindByIdChain = () => ({
+    lean: jest.fn(async () => state),
+    select: jest.fn().mockImplementation(() => makeFindByIdChain()),
+  });
+
+  beforeEach(async () => {
+    state = {
+      _id: 'user-123',
+      geminiApiKeyEncrypted: undefined,
+      geminiApiKeyLast4: null,
+      geminiApiKeyUpdatedAt: undefined,
+      openRouterApiKeyEncrypted: undefined,
+      openRouterApiKeyLast4: null,
+      openRouterApiKeyUpdatedAt: undefined,
+      preferences: {
+        activeModel: 'openai/gpt-5-mini',
+        activeProvider: 'openrouter',
+      },
+    };
+
+    mockUserModel.findById.mockImplementation(() => makeFindByIdChain());
+    mockUserModel.updateOne.mockImplementation(async (_query, update) => {
+      applyUpdate(state, update as PlainObject);
+      return { acknowledged: true };
+    });
+    mockOpenRouterModelsService.listModels.mockResolvedValue([
+      { id: 'openai/gpt-5-mini', name: 'GPT-5 Mini' },
+    ]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AiController],
+      providers: [
+        AiPolicyService,
+        {
+          provide: getModelToken(User.name),
+          useValue: mockUserModel,
+        },
+        {
+          provide: AiSecretsService,
+          useValue: mockAiSecretsService,
+        },
+        {
+          provide: OpenRouterModelsService,
+          useValue: mockOpenRouterModelsService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AiController>(AiController);
+    aiPolicyService = module.get<AiPolicyService>(AiPolicyService);
+    openRouterModelsService = module.get(OpenRouterModelsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('saving Gemini key clears OpenRouter key and persists Gemini as active provider', async () => {
+    state.openRouterApiKeyEncrypted = 'enc:sk-or-v1-previous';
+    state.openRouterApiKeyLast4 = '9999';
+    state.openRouterApiKeyUpdatedAt = new Date();
+    state.preferences.activeModel = 'openai/gpt-5-mini';
+    state.preferences.activeProvider = 'openrouter';
+
+    const result = await controller.setGeminiKey('user-123', {
+      apiKey: 'AIzaSy_test_gemini_key',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.activeProvider).toBe('gemini');
+    expect(state.openRouterApiKeyEncrypted).toBeUndefined();
+    expect(state.openRouterApiKeyLast4).toBeUndefined();
+    expect(state.openRouterApiKeyUpdatedAt).toBeUndefined();
+    expect(state.preferences.activeProvider).toBe('gemini');
+    expect(state.preferences.activeModel).toBe(
+      aiPolicyService.getDefaultModel('gemini'),
+    );
+  });
+
+  it('saving OpenRouter key clears Gemini key and persists OpenRouter as active provider', async () => {
+    state.geminiApiKeyEncrypted = 'enc:AIzaSy_previous';
+    state.geminiApiKeyLast4 = '8888';
+    state.geminiApiKeyUpdatedAt = new Date();
+    state.preferences.activeModel = 'gemini-2.0-flash';
+    state.preferences.activeProvider = 'gemini';
+
+    const result = await controller.setOpenRouterKey('user-123', {
+      apiKey: 'sk-or-v1-test-openrouter-key',
+    });
+
+    expect(openRouterModelsService.listModels).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(result.data.activeProvider).toBe('openrouter');
+    expect(state.geminiApiKeyEncrypted).toBeUndefined();
+    expect(state.geminiApiKeyLast4).toBeUndefined();
+    expect(state.geminiApiKeyUpdatedAt).toBeUndefined();
+    expect(state.preferences.activeProvider).toBe('openrouter');
+    expect(state.preferences.activeModel).toBe(
+      aiPolicyService.getDefaultModel('openrouter'),
+    );
+  });
+
+  it('GET /ai/settings returns activeProvider from persisted preferences', async () => {
+    state.geminiApiKeyEncrypted = 'enc:AIzaSy_test';
+    state.geminiApiKeyLast4 = '4321';
+    state.geminiApiKeyUpdatedAt = new Date();
+    state.preferences.activeProvider = 'gemini';
+    state.preferences.activeModel = 'gemini-2.0-flash';
+
+    const result = await controller.getSettings('user-123');
+
+    expect(result.success).toBe(true);
+    expect(result.data.activeProvider).toBe('gemini');
+    expect(result.data.activeModel).toBe('gemini-2.0-flash');
+    expect(result.data.hasGeminiKey).toBe(true);
+    expect(result.data.hasOpenRouterKey).toBe(false);
+  });
+
+  it('GET /ai/models returns Gemini models when active provider is Gemini', async () => {
+    state.geminiApiKeyEncrypted = 'enc:AIzaSy_test';
+    state.geminiApiKeyUpdatedAt = new Date();
+    state.preferences.activeProvider = 'gemini';
+    state.preferences.activeModel = 'openai/gpt-5-mini';
+
+    const result = await controller.getModels('user-123');
+
+    expect(result.success).toBe(true);
+    expect(result.data.provider).toBe('gemini');
+    expect(result.data.mode).toBe('gemini');
+    expect(result.data.models).toEqual(aiPolicyService.getGeminiModels());
+    expect(state.preferences.activeModel).toBe(
+      aiPolicyService.getDefaultModel('gemini'),
+    );
+  });
+});

--- a/packages/mukti-api/src/modules/ai/dto/ai-settings.dto.ts
+++ b/packages/mukti-api/src/modules/ai/dto/ai-settings.dto.ts
@@ -3,7 +3,8 @@ import { IsOptional, IsString } from 'class-validator';
 
 export class UpdateAiSettingsDto {
   @ApiPropertyOptional({
-    description: 'Globally active OpenRouter model id',
+    description:
+      'Globally active AI model id for the currently active provider',
     example: 'openai/gpt-5-mini',
   })
   @IsOptional()

--- a/packages/mukti-api/src/modules/conversations/__tests__/conversation.controller.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/__tests__/conversation.controller.spec.ts
@@ -72,7 +72,11 @@ describe('ConversationController', () => {
   };
 
   const mockAiPolicyService = {
+    coerceModelForProvider: jest.fn().mockReturnValue('test-model'),
+    hasUserGeminiKey: jest.fn().mockReturnValue(false),
+    hasUserOpenRouterKey: jest.fn().mockReturnValue(false),
     resolveEffectiveModel: jest.fn().mockResolvedValue(undefined),
+    resolveActiveProvider: jest.fn().mockReturnValue('openrouter'),
   };
 
   const mockAiSecretsService = {
@@ -555,6 +559,7 @@ describe('ConversationController', () => {
         'free',
         'elenchus',
         undefined,
+        'openrouter',
         false,
       );
     });

--- a/packages/mukti-api/src/modules/conversations/conversations.module.ts
+++ b/packages/mukti-api/src/modules/conversations/conversations.module.ts
@@ -21,6 +21,7 @@ import { User, UserSchema } from '../../schemas/user.schema';
 import { AiModule } from '../ai/ai.module';
 import { ConversationController } from './conversation.controller';
 import { ConversationService } from './services/conversation.service';
+import { GeminiService } from './services/gemini.service';
 import { MessageService } from './services/message.service';
 import { OpenRouterService } from './services/openrouter.service';
 import { QueueService } from './services/queue.service';
@@ -45,6 +46,7 @@ import { StreamService } from './services/stream.service';
   exports: [
     SeedService,
     ConversationService,
+    GeminiService,
     MessageService,
     OpenRouterService,
     QueueService,
@@ -97,6 +99,7 @@ import { StreamService } from './services/stream.service';
   providers: [
     SeedService,
     ConversationService,
+    GeminiService,
     MessageService,
     OpenRouterService,
     QueueService,

--- a/packages/mukti-api/src/modules/conversations/dto/send-message.dto.ts
+++ b/packages/mukti-api/src/modules/conversations/dto/send-message.dto.ts
@@ -20,7 +20,7 @@ export class SendMessageDto {
   content: string;
 
   @ApiPropertyOptional({
-    description: 'OpenRouter model id to use for this message',
+    description: 'Model id to use for this message (provider-aware)',
     example: 'openai/gpt-5-mini',
   })
   @IsOptional()

--- a/packages/mukti-api/src/modules/conversations/services/__tests__/queue.gemini-stream.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/services/__tests__/queue.gemini-stream.spec.ts
@@ -1,0 +1,226 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { ConfigService } from '@nestjs/config';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+jest.mock('@openrouter/sdk', () => ({
+  OpenRouter: jest.fn(() => ({})),
+}));
+
+import { Conversation } from '../../../../schemas/conversation.schema';
+import { Technique } from '../../../../schemas/technique.schema';
+import { UsageEvent } from '../../../../schemas/usage-event.schema';
+import { User } from '../../../../schemas/user.schema';
+import { AiPolicyService } from '../../../ai/services/ai-policy.service';
+import { AiSecretsService } from '../../../ai/services/ai-secrets.service';
+import { GeminiService } from '../gemini.service';
+import { MessageService } from '../message.service';
+import { OpenRouterService } from '../openrouter.service';
+import { QueueService } from '../queue.service';
+import { StreamService } from '../stream.service';
+
+describe('QueueService Gemini Streaming', () => {
+  let service: QueueService;
+  let streamService: { emitToConversation: jest.Mock };
+
+  beforeEach(async () => {
+    streamService = {
+      emitToConversation: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueService,
+        {
+          provide: getQueueToken('conversation-requests'),
+          useValue: {
+            add: jest.fn(),
+            getJob: jest.fn(),
+          },
+        },
+        {
+          provide: getModelToken(Conversation.name),
+          useValue: {
+            findById: jest.fn().mockResolvedValue({
+              _id: '507f1f77bcf86cd799439011',
+              recentMessages: [],
+            }),
+          },
+        },
+        {
+          provide: getModelToken(Technique.name),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({
+              template: {
+                exampleQuestions: [],
+                followUpStrategy: 'Probe assumptions',
+                questioningStyle: 'Socratic',
+                systemPrompt: 'Ask reflective questions',
+              },
+            }),
+          },
+        },
+        {
+          provide: getModelToken(UsageEvent.name),
+          useValue: {
+            create: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: getModelToken(User.name),
+          useValue: {
+            findById: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue({
+                geminiApiKeyEncrypted: 'enc:AIzaSy_test_key',
+              }),
+              select: jest.fn().mockReturnThis(),
+            }),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: AiPolicyService,
+          useValue: {
+            getCuratedModels: jest.fn(() => [
+              { id: 'openai/gpt-5-mini', label: 'GPT-5 Mini' },
+            ]),
+            isGeminiModel: jest.fn().mockReturnValue(true),
+          },
+        },
+        {
+          provide: AiSecretsService,
+          useValue: {
+            decryptString: jest.fn((value: string) =>
+              value.replace(/^enc:/, ''),
+            ),
+          },
+        },
+        {
+          provide: GeminiService,
+          useValue: {
+            sendMessage: jest.fn().mockResolvedValue({
+              completionTokens: 12,
+              content: 'Have you considered alternative assumptions?',
+              cost: 0,
+              model: 'gemini-2.0-flash',
+              promptTokens: 21,
+              totalTokens: 33,
+            }),
+          },
+        },
+        {
+          provide: MessageService,
+          useValue: {
+            addMessageToConversation: jest.fn().mockResolvedValue({
+              _id: {
+                toString: () => '507f1f77bcf86cd799439011',
+              },
+              recentMessages: [
+                {
+                  content: 'What should I improve?',
+                  role: 'user',
+                  timestamp: new Date('2025-01-01T00:00:00.000Z'),
+                },
+                {
+                  content: 'Have you considered alternative assumptions?',
+                  role: 'assistant',
+                  timestamp: new Date('2025-01-01T00:00:00.000Z'),
+                },
+              ],
+              totalMessageCount: 2,
+            }),
+            archiveOldMessages: jest.fn(),
+            buildConversationContext: jest.fn().mockReturnValue({
+              messages: [],
+              systemPrompt: 'Ask reflective questions',
+              technique: {},
+            }),
+          },
+        },
+        {
+          provide: OpenRouterService,
+          useValue: {
+            buildPrompt: jest.fn(),
+            sendChatCompletion: jest.fn(),
+          },
+        },
+        {
+          provide: StreamService,
+          useValue: streamService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<QueueService>(QueueService);
+  });
+
+  it('emits processing, message(user+assistant), and complete events for Gemini jobs', async () => {
+    const result = await service.process({
+      data: {
+        conversationId: '507f1f77bcf86cd799439011',
+        message: 'What should I improve?',
+        model: 'gemini-2.0-flash',
+        provider: 'gemini',
+        subscriptionTier: 'free',
+        technique: 'elenchus',
+        usedByok: false,
+        userId: '507f1f77bcf86cd799439012',
+      },
+      id: 'job-1',
+    } as any);
+
+    const emittedEventTypes = streamService.emitToConversation.mock.calls.map(
+      (call) => call[1].type,
+    );
+
+    expect(emittedEventTypes).toContain('processing');
+    expect(emittedEventTypes).toContain('progress');
+    expect(emittedEventTypes).toContain('message');
+    expect(emittedEventTypes).toContain('complete');
+
+    expect(streamService.emitToConversation).toHaveBeenCalledWith(
+      '507f1f77bcf86cd799439011',
+      {
+        data: {
+          content: 'What should I improve?',
+          role: 'user',
+          sequence: 1,
+          timestamp: '2025-01-01T00:00:00.000Z',
+        },
+        type: 'message',
+      },
+    );
+    expect(streamService.emitToConversation).toHaveBeenCalledWith(
+      '507f1f77bcf86cd799439011',
+      {
+        data: {
+          content: 'Have you considered alternative assumptions?',
+          role: 'assistant',
+          sequence: 2,
+          timestamp: '2025-01-01T00:00:00.000Z',
+          tokens: 33,
+        },
+        type: 'message',
+      },
+    );
+    expect(streamService.emitToConversation).toHaveBeenCalledWith(
+      '507f1f77bcf86cd799439011',
+      {
+        data: {
+          cost: 0,
+          jobId: 'job-1',
+          latency: expect.any(Number),
+          tokens: 33,
+        },
+        type: 'complete',
+      },
+    );
+
+    expect(result.tokens).toBe(33);
+  });
+});

--- a/packages/mukti-api/src/modules/conversations/services/__tests__/queue.service.spec.ts
+++ b/packages/mukti-api/src/modules/conversations/services/__tests__/queue.service.spec.ts
@@ -14,6 +14,7 @@ import { UsageEvent } from '../../../../schemas/usage-event.schema';
 import { User } from '../../../../schemas/user.schema';
 import { AiPolicyService } from '../../../ai/services/ai-policy.service';
 import { AiSecretsService } from '../../../ai/services/ai-secrets.service';
+import { GeminiService } from '../gemini.service';
 import { MessageService } from '../message.service';
 import { OpenRouterService } from '../openrouter.service';
 import { QueueService } from '../queue.service';
@@ -126,6 +127,10 @@ describe('QueueService', () => {
       sendChatCompletion: jest.fn(),
     };
 
+    const mockGeminiService = {
+      sendMessage: jest.fn(),
+    };
+
     const mockStreamService = {
       addConnection: jest.fn(),
       cleanupConversation: jest.fn(),
@@ -175,6 +180,10 @@ describe('QueueService', () => {
         {
           provide: OpenRouterService,
           useValue: mockOpenRouterService,
+        },
+        {
+          provide: GeminiService,
+          useValue: mockGeminiService,
         },
         {
           provide: StreamService,
@@ -232,6 +241,7 @@ describe('QueueService', () => {
               subscriptionTier,
               technique,
               'openai/gpt-5-mini',
+              'openrouter',
               false,
             );
 
@@ -272,6 +282,7 @@ describe('QueueService', () => {
         'free',
         'elenchus',
         'openai/gpt-5-mini',
+        'openrouter',
         false,
       );
 
@@ -283,6 +294,7 @@ describe('QueueService', () => {
         'paid',
         'dialectic',
         'openai/gpt-5-mini',
+        'openrouter',
         false,
       );
 
@@ -306,6 +318,7 @@ describe('QueueService', () => {
         'free',
         'elenchus',
         'openai/gpt-5-mini',
+        'openrouter',
         false,
       );
 
@@ -342,6 +355,7 @@ describe('QueueService', () => {
         'free',
         'elenchus',
         'openai/gpt-5-mini',
+        'openrouter',
         false,
       );
       await service.enqueueRequest(
@@ -351,6 +365,7 @@ describe('QueueService', () => {
         'paid',
         'dialectic',
         'openai/gpt-5-mini',
+        'openrouter',
         false,
       );
 
@@ -413,6 +428,7 @@ describe('QueueService', () => {
               subscriptionTier,
               technique,
               'openai/gpt-5-mini',
+              'openrouter',
               false,
             );
 
@@ -425,6 +441,7 @@ describe('QueueService', () => {
               conversationId,
               message,
               model: 'openai/gpt-5-mini',
+              provider: 'openrouter',
               subscriptionTier,
               technique,
               usedByok: false,
@@ -466,6 +483,7 @@ describe('QueueService', () => {
         'free',
         'elenchus',
         'openai/gpt-5-mini',
+        'openrouter',
         false,
       );
 

--- a/packages/mukti-api/src/modules/conversations/services/gemini.service.ts
+++ b/packages/mukti-api/src/modules/conversations/services/gemini.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import type { TechniqueTemplate } from '../../../schemas/technique.schema';
+import { GeminiClientFactory } from '../../ai/services/gemini-client.factory';
+
+export interface GeminiResponse {
+  completionTokens: number;
+  content: string;
+  cost: number;
+  model: string;
+  promptTokens: number;
+  totalTokens: number;
+}
+
+@Injectable()
+export class GeminiService {
+  private readonly logger = new Logger(GeminiService.name);
+
+  constructor(private readonly geminiClientFactory: GeminiClientFactory) {}
+
+  async sendMessage(params: {
+    apiKey: string;
+    conversationHistory: { content: string; role: string }[];
+    model: string;
+    technique: TechniqueTemplate;
+    userMessage: string;
+  }): Promise<GeminiResponse> {
+    const client = this.geminiClientFactory.create(params.apiKey);
+    const model = client.getGenerativeModel({ model: params.model });
+
+    const historyText = params.conversationHistory
+      .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+      .join('\n\n');
+    const prompt = [
+      'You are Mukti, a Socratic thinking partner.',
+      '',
+      'System instructions:',
+      params.technique.systemPrompt,
+      '',
+      'Conversation history:',
+      historyText || '(none)',
+      '',
+      'Latest user message:',
+      params.userMessage,
+      '',
+      'Reply as the assistant.',
+    ].join('\n');
+
+    this.logger.log(`Sending Gemini request with model: ${params.model}`);
+
+    const generated = await model.generateContent(prompt);
+    const response = generated.response;
+    const content = response.text();
+    const usage = (response as any).usageMetadata as
+      | {
+          candidatesTokenCount?: number;
+          promptTokenCount?: number;
+          totalTokenCount?: number;
+        }
+      | undefined;
+
+    const promptTokens = usage?.promptTokenCount ?? 0;
+    const completionTokens = usage?.candidatesTokenCount ?? 0;
+    const totalTokens =
+      usage?.totalTokenCount ?? promptTokens + completionTokens;
+
+    return {
+      completionTokens,
+      content,
+      cost: 0,
+      model: params.model,
+      promptTokens,
+      totalTokens,
+    };
+  }
+}

--- a/packages/mukti-api/src/schemas/user.schema.ts
+++ b/packages/mukti-api/src/schemas/user.schema.ts
@@ -5,6 +5,7 @@ export type UserDocument = Document & User;
 
 export interface UserPreferences {
   activeModel?: string;
+  activeProvider?: 'gemini' | 'openrouter';
   defaultTechnique?: string;
   emailNotifications?: boolean;
   language?: string;

--- a/packages/mukti-web/src/app/dashboard/settings/page.tsx
+++ b/packages/mukti-web/src/app/dashboard/settings/page.tsx
@@ -13,6 +13,7 @@ import { useAiStore } from '@/lib/stores/ai-store';
 export default function SettingsPage() {
   const {
     activeModel,
+    activeProvider,
     deleteGeminiKey,
     deleteOpenRouterKey,
     geminiKeyLast4,
@@ -20,6 +21,7 @@ export default function SettingsPage() {
     hasOpenRouterKey,
     hydrate,
     isHydrated,
+    mode,
     models,
     openRouterKeyLast4,
     refreshModels,
@@ -42,20 +44,40 @@ export default function SettingsPage() {
     }
   }, [hydrate, isHydrated]);
 
+  const openRouterActive = activeProvider === 'openrouter' && hasOpenRouterKey;
+  const geminiActive = activeProvider === 'gemini' && hasGeminiKey;
+  const selectorDescription =
+    activeProvider === 'gemini'
+      ? 'Choose which Gemini model to use.'
+      : mode === 'openrouter'
+        ? 'Choose which OpenRouter model to use.'
+        : 'Choose which curated model to use.';
+
   return (
     <DashboardLayout title="Settings">
       <div className="mx-auto w-full max-w-3xl space-y-8 p-4 md:p-6">
         <section className="space-y-3 rounded-lg border p-4">
           <h2 className="text-lg font-semibold">AI</h2>
           <p className="text-sm text-muted-foreground">
-            Pick your active model and optionally connect your own OpenRouter key.
+            Exactly one provider is active at a time. Saving a provider key activates it
+            immediately.
           </p>
 
+          <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2">
+            <span className="text-sm font-medium">Active provider</span>
+            <Badge className="capitalize" variant="outline">
+              {activeProvider}
+            </Badge>
+          </div>
+
           <div className="space-y-2">
-            <label className="text-sm font-medium">Active model</label>
+            <label className="text-sm font-medium">
+              Active model ({activeProvider === 'gemini' ? 'Gemini' : 'OpenRouter'})
+            </label>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <ModelSelector
                 className="flex-1 h-11"
+                description={selectorDescription}
                 models={models}
                 onChange={async (modelId) => {
                   setSavingModel(true);
@@ -66,6 +88,7 @@ export default function SettingsPage() {
                     setSavingModel(false);
                   }
                 }}
+                title={`Select ${activeProvider === 'gemini' ? 'Gemini' : 'OpenRouter'} Model`}
                 value={activeModel}
               />
               <Button
@@ -84,7 +107,7 @@ export default function SettingsPage() {
         <section className="space-y-3 rounded-lg border p-4">
           <h3 className="text-lg font-semibold">OpenRouter API key</h3>
           <p className="text-sm text-muted-foreground">
-            If you add a key, Mukti will use it for all AI calls.
+            Saving an OpenRouter key makes OpenRouter active and removes any Gemini key.
           </p>
 
           <div className="space-y-2">
@@ -120,13 +143,18 @@ export default function SettingsPage() {
 
             <div className="flex items-center justify-between gap-3 min-h-[44px]">
               <div>
-                {hasOpenRouterKey ? (
+                {openRouterActive ? (
                   <Badge
                     className="gap-1.5 border-green-500/50 bg-green-500/10 py-1.5 px-3 text-sm text-green-500 h-9"
                     variant="outline"
                   >
                     <CheckCircle2 className="h-4 w-4" />
-                    Connected (…{openRouterKeyLast4 ?? '????'})
+                    Active (…{openRouterKeyLast4 ?? '????'})
+                  </Badge>
+                ) : hasOpenRouterKey ? (
+                  <Badge className="gap-1.5 py-1.5 px-3 text-sm h-9" variant="secondary">
+                    <AlertCircle className="h-4 w-4" />
+                    Stored (inactive)
                   </Badge>
                 ) : (
                   <Badge
@@ -165,7 +193,9 @@ export default function SettingsPage() {
 
         <section className="space-y-3 rounded-lg border p-4">
           <h3 className="text-lg font-semibold">Gemini API key</h3>
-          <p className="text-sm text-muted-foreground">Connect your Google Gemini API key.</p>
+          <p className="text-sm text-muted-foreground">
+            Saving a Gemini key makes Gemini active and removes any OpenRouter key.
+          </p>
 
           <div className="space-y-2">
             <div className="flex flex-col gap-2 sm:flex-row">
@@ -198,13 +228,18 @@ export default function SettingsPage() {
 
             <div className="flex items-center justify-between gap-3 min-h-[44px]">
               <div>
-                {hasGeminiKey ? (
+                {geminiActive ? (
                   <Badge
                     className="gap-1.5 border-green-500/50 bg-green-500/10 py-1.5 px-3 text-sm text-green-500 h-9"
                     variant="outline"
                   >
                     <CheckCircle2 className="h-4 w-4" />
-                    Connected (…{geminiKeyLast4 ?? '????'})
+                    Active (…{geminiKeyLast4 ?? '????'})
+                  </Badge>
+                ) : hasGeminiKey ? (
+                  <Badge className="gap-1.5 py-1.5 px-3 text-sm h-9" variant="secondary">
+                    <AlertCircle className="h-4 w-4" />
+                    Stored (inactive)
                   </Badge>
                 ) : (
                   <Badge

--- a/packages/mukti-web/src/components/ai/model-selector.tsx
+++ b/packages/mukti-web/src/components/ai/model-selector.tsx
@@ -18,7 +18,9 @@ import { cn } from '@/lib/utils';
 
 interface ModelSelectorProps {
   className?: string;
+  description?: string;
   disabled?: boolean;
+  title?: string;
   models: AiModelOption[];
   onChange: (modelId: string) => void;
   value?: null | string;
@@ -28,9 +30,11 @@ const MAX_RENDERED_MODELS = 250;
 
 export function ModelSelector({
   className,
+  description = 'Choose which model to use for your next message.',
   disabled = false,
   models,
   onChange,
+  title = 'Select Model',
   value,
 }: ModelSelectorProps) {
   const [open, setOpen] = React.useState(false);
@@ -78,10 +82,8 @@ export function ModelSelector({
       <Dialog onOpenChange={setOpen} open={open}>
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle>Select Model</DialogTitle>
-            <DialogDescription>
-              Choose which OpenRouter model to use for your next message.
-            </DialogDescription>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
 
           <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Persist `preferences.activeProvider` (`openrouter`/`gemini`) and enforce a single active provider by clearing the other BYOK key on save.
- Make models/settings provider-aware and route the conversation send + queue processing through the active provider (adds Gemini model support).
- Improve streaming reliability: align Gemini SSE events with OpenRouter, add a Redis-backed stream fanout bridge, and add a best-effort web polling fallback.

## Tests
- `bun run test -- src/modules/ai/__tests__/ai.controller.spec.ts src/modules/conversations/services/__tests__/queue.gemini-stream.spec.ts src/modules/conversations/services/__tests__/queue.service.spec.ts src/modules/conversations/__tests__/conversation.controller.spec.ts` (in `packages/mukti-api`)
- `bun run test -- src/lib/hooks/__tests__/use-conversations.spec.ts` (in `packages/mukti-web`)
